### PR TITLE
RSS取得中だけ一時的にセッションを閉じる修正

### DIFF
--- a/manager/includes/rss.inc.php
+++ b/manager/includes/rss.inc.php
@@ -35,7 +35,11 @@ $feedData = array();
 // create Feed
 foreach ($urls as $section=>$url) {
 	$output = '';
+    // While getting RSS, SESSION is closed temporarily.  
+    $tmp_sessionname=session_name();
+    session_write_close();
     $rss = @fetch_rss($url);
+    session_start($tmp_sessionname);
     if( !$rss ){
     	$feedData[$section] = 'Failed to retrieve ' . $url;
     	continue;


### PR DESCRIPTION
外部RSSに問題がありうまくRSSを取得できない時、セッションを保持したまま固まるためしばらく管理画面の操作ができなくなります。
RSS取得中のみ一時的にセッションを閉じておけば、RSSに問題がありダッシュボードが表示されなくても、RSS取得のタイムアウトを待たず別のページにすぐに移動することができます。
