### PR TITLE
管理画面で何もしないアクション(998)の追加

### DIFF
--- a/manager/index.php
+++ b/manager/index.php
@@ -214,7 +214,9 @@ if (isset($modx->config['validate_referer']) && intval($modx->config['validate_r
 }
 
 // invoke OnManagerPageInit event
-$modx->invokeEvent("OnManagerPageInit", array("action" => $action));
+// If you would like to output $evtOutOnMPI , set $action to 999 or 998 in Plugin. 
+//   ex)$modx->event->setGlobalVariable('action',999);
+$evtOutOnMPI = $modx->invokeEvent("OnManagerPageInit", array("action" => $action));
 
 // Now we decide what to do according to the action request. This is a BIG list :)
 switch ($action)
@@ -663,12 +665,13 @@ switch ($action)
 	case 501: //delete category
 		include_once "processors/delete_category.processor.php";
 		break;
-	case 998: //No action
-		break;
-	case 999: // get the test page
+	case 998: //Output of OnManagerPageInit with Header/Footer
 		include_once "header.inc.php";
-		include_once "test_page.php";
+		if (is_array($evtOutOnMPI)) echo implode('', $evtOutOnMPI);
 		include_once "footer.inc.php";
+		break;
+	case 999: //Output of OnManagerPageInit
+		if (is_array($evtOutOnMPI)) echo implode('', $evtOutOnMPI);
 		break;
 	default : // default action: show not implemented message
 		// say that what was requested doesn't do anything yet


### PR DESCRIPTION
OnManagerPageInitイベントで完全にMODXの処理を代行した際に、アクション分岐のところで何も出力しないようにするためのアクションです。
本当はアクション0にしようとしたのですが、0の場合はロギング処理でエラーになりました。
次に999にしようとしたのですが、テスト用のアクションとぶつかりました。
結局998にしてます…。
