### PR TITLE
ユーザ情報編集時のパスワードメール送信タイミングの変更

### DIFF
--- a/manager/processors/save_user.processor.php
+++ b/manager/processors/save_user.processor.php
@@ -260,9 +260,6 @@ switch ($_POST['mode']) {
 			}
 			$updatepasswordsql = ", password=MD5('{$newpassword}') ";
 		}
-		if ($passwordnotifymethod == 'e') {
-			sendMailMessage($email, $newusername, $newpassword, $fullname);
-		}
 
 		// check if the username already exist
 		if (!$rs = $modx->db->select('id',$tbl_manager_users,"username='{$newusername}'")) {
@@ -351,6 +348,10 @@ switch ($_POST['mode']) {
 				"username" => $newusername,
 				"userpassword" => $newpassword
 			));
+
+		if ($passwordnotifymethod == 'e') {
+			sendMailMessage($email, $newusername, $newpassword, $fullname);
+		}
 
 		// invoke OnUserFormSave event
 		$modx->invokeEvent("OnUserFormSave", array (


### PR DESCRIPTION
ユーザ情報編集時のパスワードメール送信タイミングをOnManagerChangePasswordイベントの後に設定しました。
このイベントで色々調整する事があるかもしれないですが、その時に既にメールが送られてるのは変かなと思ってずらしたのですが、最初に送っている意図って何かありましたっけ？
特になければこの位置に持ってきたいなと思ってます。
