### PR TITLE
テンプレート変数のhtmlTag出力ウィジェットtagid付加ルール修正

### DIFF
--- a/manager/includes/tmplvars.format.inc.php
+++ b/manager/includes/tmplvars.format.inc.php
@@ -162,7 +162,7 @@ function getTVDisplayFormat($name,$value,$format,$paramstring='',$tvtype='',$doc
 				$tagvalue = $modx->parsePlaceholder($params['output'],array('value'=>$tagvalue));
 				$attributes = '';
 				$attr = array(
-					'id' => ($tagid ? $tagid : $tagname) . ($i+1), // 'tv' already added to id
+					'id' => ($tagid ? $tagid : $tagname) . ($i==0?'':'-'.$i), //１周目は指定されたidをそのまま付加する。'tv' already added to id
 					'class' => $params['class'],
 					'style' => $params['style'],
 				);


### PR DESCRIPTION
テンプレート変数の「ウィジェット(出力フィルタ)」の「HTML Generic Tag」による整形ルールのうち、タグに振られるidは指定したid（パラメータTag ID）に数字が付加されたものになる仕様のようです。
ここはTag IDで指定したidそのものが振られるべきだと思いますので、リクエストしてみます。
# 制作中のサイトで、ページ内リンクがうまく動作しないために気づきました。
