### PR TITLE
ditto.class.inc.php修正案

### DIFF
--- a/assets/snippets/ditto/classes/ditto.class.inc.php
+++ b/assets/snippets/ditto/classes/ditto.class.inc.php
@@ -683,7 +683,7 @@ class ditto {
 	function getParentList() {
 		global $modx;
 		$kids = array();
-		if(method_exists($modx, 'setdocumentMap') && !isset($modx->documentMap))
+		if(method_exists($modx, 'setdocumentMap') && empty($modx->documentMap))
 		{
 			$modx->setdocumentMap();
 		}
@@ -801,7 +801,7 @@ class ditto {
 		$kids = array();
 		$docIDs = array();
 		
-		if(method_exists($modx, 'setdocumentMap') && !isset($modx->documentMap))
+		if(method_exists($modx, 'setdocumentMap') && empty($modx->documentMap))
 		{
 			$modx->setdocumentMap();
 		}


### PR DESCRIPTION
「document.parser.class.inc.php」において、マジックメソッドである「__get」で
$this->setdocumentMap();を呼び出しているため、
!isset($modx->documentMap)
は常にFALSEになってしまう。