### PR TITLE
エイリアスとリソースIDの重複判定の修正

### DIFF
--- a/manager/processors/move_document.processor.php
+++ b/manager/processors/move_document.processor.php
@@ -140,7 +140,7 @@ function update_parentid($doc_id,$new_parent,$user_id,$menuindex)
 	{
 		$rs = $modx->db->select("IF(alias='', id, alias) AS alias",$tbl_site_content, "id='{$doc_id}'");
 		$alias = $modx->db->getValue($rs);
-		$rs = $modx->db->select('id',$tbl_site_content, "parent='{$new_parent}' AND (alias='{$alias}' OR id='{$alias}')");
+		$rs = $modx->db->select('id',$tbl_site_content, "parent='{$new_parent}' AND (alias='{$alias}' OR (alias='' AND id='{$alias}'))");
 		$find = $modx->db->getRecordcount($rs);
 		if(0<$find)
 		{


### PR DESCRIPTION
コンテナ内で自動採番にしている際など、エイリアスとIDが一致して、移動先で弾かれる事例が発生します（エイリアス同士も一致しがちではありますが）。少なくとも、リソースIDとエイリアスが一致して問題になるのは、aliasが空欄の時のみだと思いますので、ご検討お願いします。