### PR TITLE
PHxモディファイア「money_format」を追加

### DIFF
--- a/manager/includes/extenders/phx.parser.class.inc.php
+++ b/manager/includes/extenders/phx.parser.class.inc.php
@@ -409,6 +409,10 @@ class PHx {
 			case 'string_format':
 				if($value!=='') $value = sprintf($opt,$value);
 				break;
+                        case 'money_format':
+                                setlocale(LC_MONETARY,setlocale(LC_TIME,0));
+                                if($value!=='') $value = money_format($opt,$value);
+                                break;
 			case 'cat':
 			case '.':
 				if($value!=='') $value = $value . $opt;


### PR DESCRIPTION
[+変数:money_format(フォーマット)+]
http://php.net/manual/ja/function.money-format.php
直前にconfig.inc.phpで設定されている時間ロケール（LC_TIME）を通貨数値ロケール（LC_MONETARY）に設定する。
フォーマットを「%!.0n」とすれば、カンマ区切り数値として表示できる。