### PR TITLE
モディファイア追加

### DIFF
--- a/manager/includes/extenders/ex_modifiers.php
+++ b/manager/includes/extenders/ex_modifiers.php
@@ -650,6 +650,8 @@ class MODIFIERS {
                     $result[] = $child['id'];
                 }
                 return join(',', $result);
+            case 'fullurl':
+                return $modx->makeUrl($value);
                 
             #####  File system
             case 'getimageinfo':
@@ -766,6 +768,12 @@ class MODIFIERS {
                 $i = $value + $c;
                 $i = $i % $c;
                 return $_[$i];
+            case 'takeval':
+                $arr = explode(",",$opt);
+                $idx = $value;
+                if(!is_numeric($idx)) return $value;
+                return $arr[$idx];
+                break;
             case 'getimage':
                 return $this->includeMdfFile('getimage');
             case 'nicesize':

--- a/manager/includes/extenders/ex_modifiers.php
+++ b/manager/includes/extenders/ex_modifiers.php
@@ -773,7 +773,6 @@ class MODIFIERS {
                 $idx = $value;
                 if(!is_numeric($idx)) return $value;
                 return $arr[$idx];
-                break;
             case 'getimage':
                 return $this->includeMdfFile('getimage');
             case 'nicesize':


### PR DESCRIPTION
fullurl：与えられた数値をリソースIDとしてフルURLを出力
例）[*id:fullurl*] => http://～/XXX.html

takeval：与えられた数値を配列の要素番号として、対応するオプション（カンマ区切り）の文字列を出力
例）[*2:takeval(東京,神奈川,埼玉,千葉)*] => 埼玉