### PR TITLE
@1234/uの記法処理の修正案（typoと/uスイッチ判定にpreg_match利用）

### DIFF
--- a/manager/includes/document.parser.class.inc.php
+++ b/manager/includes/document.parser.class.inc.php
@@ -1397,8 +1397,9 @@ class DocumentParser {
             
             if(strpos($key,'@')!==false)
             {
-                if(strpos($key,'/u')!==false)
-                    $key = str_replace(array('@','/u'),array('@u(',')u'),$key);
+                //if(strpos($key,'/u')!==false)
+                if(preg_match('/@\d+\/u/',$key))
+                    $key = str_replace(array('@','/u'),array('@u(',')'),$key);
                 list($key,$str) = explode('@',$key,2);
                 $context = strtolower($str);
                 if(substr($str,0,5)==='alias' && strpos($str,'(')!==false)


### PR DESCRIPTION
[*pagetitle@3/u*]の記法対応にちょっとした間違い（→@u(3)uに読み替えちゃう）の修正と，
[*apgetitle@alias(aaa/uuu)*]への対応（案）です。
個人的には「/u」は廃止でも良いと思いますけれども。
c.f. http://forum.modx.jp/viewtopic.php?f=32&t=1652