### PR TITLE
is_file,file_exists等のモディファイアに渡すパスの相対化

### DIFF
--- a/manager/includes/extenders/ex_modifiers.php
+++ b/manager/includes/extenders/ex_modifiers.php
@@ -254,8 +254,7 @@ class MODIFIERS {
                 if(!$opt) $path = $value;
                 else      $path = $opt;
                 if(strpos($path,MODX_MANAGER_PATH)!==false) exit('Can not read core path');
-                if(!$opt) $path = $value;
-                else      $path = $opt;
+                if(strpos($path,$modx->config['base_path'])===false) $path = ltrim($path,'/');
                 $this->condition[] = intval($cmd($path)!==false);break;
             case 'is_image':
                 if(!$opt) $path = $value;


### PR DESCRIPTION
file_exists等のモディファイア利用時，引数が絶対パス(/content/〜など)の場合，一律にfalseになってしまうので，base_pathを含まない場合は相対パスとしてはどうでしょうか？
ご検討いただければ幸いです。