### PR TITLE
limit,trim_toモディファイアの挙動修正案

### DIFF
--- a/manager/includes/extenders/ex_modifiers.php
+++ b/manager/includes/extenders/ex_modifiers.php
@@ -455,11 +455,12 @@ class MODIFIERS {
                     $str = '';
                 }
                 if($len==='') $len = 100;
+                if(abs($len) > $this->strlen($value)) $str ='';
                 if(preg_match('/^[1-9][0-9]*$/',$len)) {
                     return $this->substr($value,0,$len) . $str;
                 }
                 elseif(preg_match('/^\-[1-9][0-9]*$/',$len)) {
-                    return $this->substr($value,$len) . $str;
+                    return $str . $this->substr($value,$len);
                 }
                 break;
             case 'summary':


### PR DESCRIPTION
１.(N+…)としたとき，現状では実際の文字数にかかわらず，一律に指定suffixが付加されますが，実際の文字数がNを超えている場合だけ付加されて欲しいです（MTの仕様も同様なので）
２.マイナス値指定時は末尾から切り取る仕様ですが，これはprefixとして付加された方が良いように思います。