### PR TITLE
Ditto json.formatにタブ（\t）のエスケープ追加案

### DIFF
--- a/assets/snippets/ditto/formats/json.format.inc.php
+++ b/assets/snippets/ditto/formats/json.format.inc.php
@@ -64,7 +64,8 @@ if(!function_exists("json_parameters")) {
 			$value = addslashes(htmlspecialchars($value,ENT_QUOTES, $modx->config['modx_charset']));
 			if($name=='date' && !preg_match('@^[0-9]+$@',$value))
 				$value = $modx->getUnixtimeFromDateString($value);
-			$jsonArr["json_{$name}"] = str_replace(array("\r\n","\n", "\r"), '\n', $value);
+			$value = str_replace(array("\r\n","\n", "\r"), '\n', $value);
+			$jsonArr["json_{$name}"] = str_replace("\t", '\t', $value);
 		}
 		$placeholders = array_merge($jsonArr,$placeholders);
 		return $placeholders;


### PR DESCRIPTION
jsonでは水平タブをエスケープする必要があるので検討いただけると幸いです。
