### PR TITLE
テンプレート変数が設定されたテンプレートでのエディタ切り替え時のエラー対策

### DIFF
--- a/manager/actions/document/mutate_content.functions.inc.php
+++ b/manager/actions/document/mutate_content.functions.inc.php
@@ -980,6 +980,7 @@ function fieldsTV() {
 		// post back value
 		if(isset($form_v[$tvid])){
 			switch( $tv['type'] ){
+			case 'checkbox':
 			case 'listbox-multiple':
 				$tvPBV = implode('||', $form_v[$tvid]);
 				break;


### PR DESCRIPTION
症状の詳細はフォーラムにて記載されており、同じ症状でした。
http://forum.modx.jp/viewtopic.php?f=32&t=1840

テンプレート変数が特定のテンプレートに設定されているケース（私の環境ではチェックボックス）にて、
そのページを編集しようとすると同様のエラーが出ました。

症状としましては、メソッド$modx->renderFormElement())の第5引数にはstringを渡されないといけないのですが、arrayが代入されてしまっているようです。
L984の'listbox-multple'のケースでは、arrayを"||"つなぎのstringsに変換していましたので、
'checkbox'のケースも追加することで、とりあえずエラーは出なくなりました。

テストがないため、ラジオボタンや、他の入力フォーマットでの複数症状がわかりません。