### PR TITLE
goolgemapウィジェットの不具合対応について

### DIFF
--- a/assets/plugins/managermanager/widgets/googlemap/googlemap.js
+++ b/assets/plugins/managermanager/widgets/googlemap/googlemap.js
@@ -1,85 +1,82 @@
+var mm_gmap = {
+  map: {},
+  marker: {},
+  addressField: {},
+  init: {},
+  draw: {},
+  addMarker: {},
+  geoSearch: {}
+};
+
 var $j = jQuery.noConflict();
-var map = {};
-var marker = {};
-var addressField = {};
 
-function googlemap(id, defaultGeoLoc) {
-    mapContainerId = "map_canvas_" + id;
-    // google maps js is loaded async, so we (loop) wait for it
-    if (!google || !google.maps) {
-        setTimeout('googlemap("' + id + '","' + defaultGeoLoc + '");', 200);
+mm_gmap.init = function(id,defaultGeoLoc) {
+  mapContainerId = "map_canvas_"+id;
+  $j("#"+id).after("<div id='"+mapContainerId+"' style='width: 500px; height: 300px; margin:5px 0 7px;'>Loading map, please wait...</div>");
+  $j("#"+mapContainerId).after("<input type='text' id='search_address_" + id + "' value=''><input type='button' onclick='mm_gmap.geoSearch(" + '"' + mapContainerId + '"' + ");' value='Search'>");
+  $j("#"+mapContainerId).data("googlemap_tvId",id);
+  $j("#"+mapContainerId).data("googlemap_defaultGeoLocation",defaultGeoLoc);
+  mm_gmap.addressField[id] = document.getElementById('search_address_'+id);
+  mm_gmap.draw(mapContainerId);
+};
+
+mm_gmap.draw = function(mapContainerId) {
+  let tvId = $j("#"+mapContainerId).data("googlemap_tvId");
+  let defaultGeoLoc = $j("#"+mapContainerId).data("googlemap_defaultGeoLocation");
+  let geoLoc;
+  let initOverlay = false;
+
+  if ($j("#"+tvId).val() != '') {		// TV contains a value already?
+    geoLoc = $j("#"+tvId).val().split(',');
+    initOverlay = true;
+  }else {
+    geoLoc = (defaultGeoLoc != '')? defaultGeoLoc.split(',') : new Array(35.6585805,139.74543289999997);	// get default from mm_rules, otherwise head to berlin
+  }
+
+  let center = new google.maps.LatLng(geoLoc[0], geoLoc[1]);
+  let mapOptions = {
+    disableDoubleClickZoom:true,
+    center: center,
+    zoom: 16,
+    mapTypeId: google.maps.MapTypeId.ROADMAP
+  };
+  mm_gmap.map[tvId] = new google.maps.Map(document.getElementById(mapContainerId),mapOptions);
+  geocoder = new google.maps.Geocoder();
+
+  if (initOverlay) {
+    mm_gmap.addMarker(center,tvId); 
+  }
+
+  google.maps.event.addListener(mm_gmap.map[tvId], 'dblclick', function(point) {
+    mm_gmap.addMarker(point.latLng,tvId);
+  });
+};
+
+mm_gmap.addMarker = function(myLatLng,tvId){
+	if(mm_gmap.marker[tvId]){mm_gmap.marker[tvId].setMap(null);}
+	mm_gmap.marker[tvId] = new google.maps.Marker({
+		position: myLatLng,
+		map: mm_gmap.map[tvId],
+		draggable:true
+	});
+	mm_gmap.map[tvId].setCenter(myLatLng);
+	$j("#"+tvId).val(myLatLng.lat() + ',' + myLatLng.lng());
+
+	// drag marker listeners
+	google.maps.event.addListener(mm_gmap.marker[tvId], "dragend", function(point) { 
+		$j("#"+tvId).val(point.latLng.lat() + ',' + point.latLng.lng());
+	});
+};
+
+mm_gmap.geoSearch = function(mapContainerId) {
+  let tvId = $j("#"+mapContainerId).data("googlemap_tvId");
+  geocoder.geocode( {'address': mm_gmap.addressField[tvId].value}, function(results, status) { 
+    if (status == google.maps.GeocoderStatus.OK) { 
+      let loc = results[0].geometry.location;
+      mm_gmap.addMarker(loc,tvId);
     } else {
-        $j("#" + id).after("<div id='" + mapContainerId + "' style='width: 500px; height: 300px; margin:5px 0 7px;'>Loading map, please wait...</div>");
-        $j("#" + mapContainerId).after("<input type='text' id='search_address_" + id + "' value=''><input type='button' onclick='geoSearch(" + '"' + mapContainerId + '"' + ");' value='Search'>");
-        $j("#" + mapContainerId).data("googlemap_tvId", id);
-        $j("#" + mapContainerId).data("googlemap_defaultGeoLocation", defaultGeoLoc);
-        addressField[id] = document.getElementById('search_address_' + id);
-        StartGoogleMaps(mapContainerId);
+      alert("Not found: " + status); 
     }
-}
-
-
-function StartGoogleMaps(mapContainerId) {
-
-    var tvId = $j("#" + mapContainerId).data("googlemap_tvId");
-    var defaultGeoLoc = $j("#" + mapContainerId).data("googlemap_defaultGeoLocation");
-    var geoLoc;
-    var initOverlay = false;
-
-    if ($j("#" + tvId).val() != '') {		// TV contains a value already?
-        geoLoc = $j("#" + tvId).val().split(',');
-        initOverlay = true;
-    } else {
-        geoLoc = (defaultGeoLoc != '') ? defaultGeoLoc.split(',') : [35.6585805, 139.74543289999997];	// get default from mm_rules, otherwise head to berlin
-    }
-
-    var center = new google.maps.LatLng(geoLoc[0], geoLoc[1]);
-    var mapOptions = {
-        disableDoubleClickZoom: true,
-        center: center,
-        zoom: 16,
-        mapTypeId: google.maps.MapTypeId.ROADMAP
-    };
-    map[tvId] = new google.maps.Map(document.getElementById(mapContainerId), mapOptions);
-    geocoder = new google.maps.Geocoder();
-
-    if (initOverlay) {
-        addMarker(center, tvId);
-    }
-
-    google.maps.event.addListener(map[tvId], 'dblclick', function (point) {
-        addMarker(point.latLng, tvId);
-    });
-}
-
-
-function addMarker(myLatLng, tvId) {
-    if (marker[tvId]) {
-        marker[tvId].setMap(null);
-    }
-    marker[tvId] = new google.maps.Marker({
-        position: myLatLng,
-        map: map[tvId],
-        draggable: true
-    });
-    map[tvId].setCenter(myLatLng);
-    $j("#" + tvId).val(myLatLng.lat() + ',' + myLatLng.lng());
-
-    // drag marker listeners
-    google.maps.event.addListener(marker[tvId], "dragend", function (point) {
-        $j("#" + tvId).val(point.latLng.lat() + ',' + point.latLng.lng());
-    });
-}
-
-function geoSearch(mapContainerId) {
-    var tvId = $j("#" + mapContainerId).data("googlemap_tvId");
-    geocoder.geocode({'address': addressField[tvId].value}, function (results, status) {
-        if (status == google.maps.GeocoderStatus.OK) {
-            var loc = results[0].geometry.location;
-            addMarker(loc, tvId);
-        } else {
-            alert("Not found: " + status);
-        }
-    });
-}
+  });
+};
 

--- a/assets/plugins/managermanager/widgets/googlemap/googlemap.php
+++ b/assets/plugins/managermanager/widgets/googlemap/googlemap.php
@@ -3,50 +3,44 @@
 // mm_widget_googlemap ver 0.12
 // 2010 / Oori
 // Free for all
-//---------------------------------------------------------------------------------
-function mm_widget_googlemap($fields, $googleApiKey = '', $default = '', $roles = '', $templates = '')
-{
+//--------------------------------------------------------------------------------- 
+function mm_widget_googlemap($fields, $googleApiKey='', $default='', $roles='', $templates='') {
+	
+	global $modx, $mm_fields,$mm_current_page,$modx_lang_attribute;
+	$e = &$modx->event;
+	
+	if ($e->name==='OnDocFormRender'&&useThisRule($roles, $templates))
+	{
+		$output = '';
+		$callBack ='';
+		
+		$fields = makeArray($fields);
+		$count = tplUseTvs($mm_current_page['template'], $fields);
+		if ($count == false)
+		{
+			return;
+		}
+		
+		$output .= "//  -------------- googlemap widget ------------- \n";
+		$output .= includeJs($modx->config['base_url'] .'assets/plugins/managermanager/widgets/googlemap/googlemap.js');
 
-    global $modx, $mm_fields, $mm_current_page;
-    $e = &$modx->event;
+		foreach ($fields as $targetTv)
+		{
+			$tv_id = $mm_fields[$targetTv]['fieldname'];
+			$callBack .= "mm_gmap.init('$tv_id','$default');";
+		}
 
-    if ($e->name !== 'OnDocFormRender' || !useThisRule($roles, $templates)) {
-        return;
-    }
+      $googleApiKey = $googleApiKey ?? '';
 
-    $output = '';
-    $callBack = '';
-
-    $fields = makeArray($fields);
-    $count = tplUseTvs($mm_current_page['template'], $fields);
-    if ($count == false) {
-        return;
-    }
-
-    $output .= "//  -------------- googlemap widget ------------- \n";
-    $output .= includeJs(MODX_BASE_URL . 'assets/plugins/managermanager/widgets/googlemap/googlemap.js');
-
-    foreach ($fields as $targetTv) {
-        $tv_id = $mm_fields[$targetTv]['fieldname'];
-        $callBack .= "googlemap('$tv_id','$default');";
-    }
-
-    $params = '';
-    if (!empty($googleApiKey)) {
-        $params = 'key=' . trim($googleApiKey);
-    }
-
-    $output .= "
-    jQuery.getScript('https://www.google.com/jsapi', function()
-    {
-        google.load('maps', '3', { other_params: '" . $params . "', callback: function()
-        {
-    " .
-        $callBack
-        .
-        "
-        }});
-    });
-    ";
-    $e->output($output . "\n");    // Send the output to the browser
+	  $output .=<<<EOP
+        var gmap_script = document.createElement('script');
+        gmap_script.src = 'https://maps.googleapis.com/maps/api/js?v=3.51&key=$googleApiKey&callback=initMap';
+        gmap_script.async = true;
+        window.initMap = function(){
+          $callBack
+        }
+        document.body.appendChild(gmap_script);
+EOP;
+	  $e->output($output . "\n");	// Send the output to the browser
+	}
 }

--- a/manager/actions/header.inc.php
+++ b/manager/actions/header.inc.php
@@ -55,7 +55,6 @@ $evtOut = evo()->invokeEvent('OnManagerMainFrameHeaderHTMLBlock');
     ?>
     <script src="media/script/jquery/jquery.powertip.min.js" type="text/javascript"></script>
     <script src="media/script/jquery/jquery.alerts.js" type="text/javascript"></script>
-    <script src="media/script/mootools/mootools.js" type="text/javascript"></script>
     <script type="text/javascript" src="media/script/tabpane.js"></script>
     <script type="text/javascript">
         var treeopen = <?php echo $modx->config('tree_pane_open_default', 1);?>;


### PR DESCRIPTION
よくよく検証したところ、影響は、mootools.jsによるものでした。
[https://developers.google.com/maps/documentation/javascript/best-practices?hl=ja](https://developers.google.com/maps/documentation/javascript/best-practices?hl=ja)
なので、既存のwidgetsを入れ替えずとも、mootools.jsの読み込みを停止すると、一応は動くようです。
廃止関数は使わない方が良いので、書き方を変えたり、関数名の重複などの影響を疑って書き換えたりしたのですが・・・。

こちらで検証した限りでは、完全に動かないAPIが v3.52からで、API v3.51を指定している分にはmootoolsを削除しなくても動くようです（３ヶ月単位でアップデートされるようなので年内には3.51も利用できなくなるような気がします）。

ということで、根本的には、mootools.jsを削除するのがよさそうなのですが、他への影響がわからないため、ご判断いただけますでしょうか？