### PR TITLE
fix: ensure dbase is properly initialized to avoid potential errors

### DIFF
--- a/assets/plugins/qm/qm.inc.php
+++ b/assets/plugins/qm/qm.inc.php
@@ -189,8 +189,7 @@ class Qm
 
     function checkAccess()
     {
-        // If user is admin (role = 1)
-        if (sessionv('mgrRole') == 1) {
+        if (manager()->isAdmin()) {
             return true;
         }
 

--- a/manager/actions/document/document_data.static.php
+++ b/manager/actions/document/document_data.static.php
@@ -29,7 +29,7 @@ evo()->updatePublishStatus();
 $where = array(
     sprintf("sc.id ='%s'", $id)
 );
-if (sessionv('mgrDocgroups') && sessionv('mgrRole') != 1) {
+if (sessionv('mgrDocgroups') && !manager()->isAdmin()) {
     $where[] = sprintf(
         "AND (sc.privatemgr=0 OR dg.document_group IN (%s))",
         implode(',', sessionv('mgrDocgroups'))

--- a/manager/actions/document/document_data.static.php
+++ b/manager/actions/document/document_data.static.php
@@ -80,9 +80,15 @@ if ($row = db()->getRow($rs)) {
 }
 
 // Get Template name
-$rs = db()->select('templatename', '[+prefix+]site_templates', "id='{$content['template']}'");
+$rs = db()->select(
+    'templatename',
+    '[+prefix+]site_templates',
+    sprintf("id='%s'", entity('template'))
+);
 if ($row = db()->getRow($rs)) {
     $templatename = $row['templatename'];
+} else {
+    $templatename = 'blank';
 }
 
 // Set the item name for logging
@@ -90,6 +96,12 @@ $_SESSION['itemname'] = $content['pagetitle'];
 
 foreach ($content as $k => $v) {
     $content[$k] = hsc($v);
+}
+
+function entity($key, $default = null)
+{
+    global $content;
+    return $content[$key] ?? $default;
 }
 
 ?>
@@ -170,7 +182,7 @@ foreach ($content as $k => $v) {
                 <?php
                 if (isset($content['parent']) && $content['parent'] != 0) {
                     $tpl = 'document.location.href=\'index.php?a=120&id=%s\';';
-                    echo sprintf($tpl, $content['parent']);
+                    echo sprintf($tpl, entity('parent'));
                 } elseif (getv('pid')) {
                     $tpl = 'document.location.href=\'index.php?a=120&id=%d\';';
                     echo sprintf($tpl, (int)getv('pid'));
@@ -203,7 +215,7 @@ foreach ($content as $k => $v) {
                 <table>
                     <tr>
                         <td width="200">ID:</td>
-                        <td><?= $content['id'] ?></td>
+                        <td><?= entity('id') ?></td>
                         <td>[*id*]</td>
                     </tr>
                     <tr>
@@ -212,7 +224,7 @@ foreach ($content as $k => $v) {
                             echo sprintf(
                                 '%s(id:%s)',
                                 $templatename,
-                                $content['template']
+                                entity('template')
                             );
                             ?>
                         </td>
@@ -220,14 +232,14 @@ foreach ($content as $k => $v) {
                     </tr>
                     <tr>
                         <td><?= $_lang['resource_title'] ?>:</td>
-                        <td><?= $content['pagetitle'] ?></td>
+                        <td><?= entity('pagetitle') ?></td>
                         <td>[*pagetitle*]</td>
                     </tr>
                     <tr>
                         <td><?= $_lang['long_title'] ?>:</td>
                         <td><?php
-                            if ($content['longtitle'] != '') {
-                                echo $content['longtitle'];
+                            if (entity('longtitle') != '') {
+                                echo entity('longtitle');
                             } else {
                                 echo "(<i>" . $_lang['not_set'] . "</i>)";
                             } ?>
@@ -237,8 +249,8 @@ foreach ($content as $k => $v) {
                     <tr>
                         <td><?= $_lang['resource_description'] ?>:</td>
                         <td><?=
-                            $content['description'] != ''
-                                ? $content['description']
+                            entity('description') != ''
+                                ? entity('description')
                                 : "(<i>" . $_lang['not_set'] . "</i>)"
                             ?></td>
                         <td>[*description*]</td>
@@ -246,8 +258,8 @@ foreach ($content as $k => $v) {
                     <tr>
                         <td><?= $_lang['resource_summary'] ?>:</td>
                         <td><?=
-                            $content['introtext'] != ''
-                                ? $content['introtext']
+                            entity('introtext') != ''
+                                ? entity('introtext')
                                 : "(<i>" . $_lang['not_set'] . "</i>)"
                             ?></td>
                         <td>[*introtext*]</td>
@@ -255,7 +267,7 @@ foreach ($content as $k => $v) {
                     <tr>
                         <td><?= $_lang['type'] ?>:</td>
                         <td><?=
-                            $content['type'] === 'reference'
+                            entity('type') === 'reference'
                                 ? $_lang['weblink']
                                 : $_lang['resource']
                             ?></td>
@@ -264,8 +276,8 @@ foreach ($content as $k => $v) {
                     <tr>
                         <td><?= $_lang['resource_alias'] ?>:</td>
                         <td><?=
-                            $content['alias'] != ''
-                                ? $content['alias']
+                            entity('alias') != ''
+                                ? entity('alias')
                                 : "(<i>" . $_lang['not_set'] . "</i>)"
                             ?></td>
                         <td>[*alias*]</td>
@@ -274,7 +286,7 @@ foreach ($content as $k => $v) {
                         <td width="200"><?= $_lang['page_data_created'] ?>:</td>
                         <td><?=
                             evo()->toDateFormat(
-                                $content['createdon'] + evo()->config('server_offset_time', 0)
+                                entity('createdon') + evo()->config('server_offset_time', 0)
                             )
                             ?>
                             (<b><?= $createdbyname ?></b>)
@@ -284,7 +296,7 @@ foreach ($content as $k => $v) {
                     <?php if ($editedbyname != '') { ?>
                         <tr>
                             <td><?= $_lang['page_data_edited'] ?>:</td>
-                            <td><?= evo()->toDateFormat($content['editedon'] + evo()->config('server_offset_time', 0)) ?>
+                            <td><?= evo()->toDateFormat(entity('editedon') + evo()->config('server_offset_time', 0)) ?>
                                 (<b><?= $editedbyname ?></b>)
                             </td>
                             <td>[*editedon:date*]</td>
@@ -293,7 +305,7 @@ foreach ($content as $k => $v) {
                     <tr>
                         <td width="200"><?= $_lang['page_data_status'] ?>:</td>
                         <td><?=
-                            $content['published'] == 0
+                            entity('published') == 0
                                 ? '<span class="unpublishedDoc">' . $_lang['page_data_unpublished'] . '</span>'
                                 : '<span class="publisheddoc">' . $_lang['page_data_published'] . '</span>'
                             ?></td>
@@ -302,45 +314,45 @@ foreach ($content as $k => $v) {
                     <tr>
                         <td><?= $_lang['page_data_publishdate'] ?>:</td>
                         <td><?=
-                            $content['pub_date'] == 0
+                            entity('pub_date') == 0
                                 ? "(<i>" . $_lang['not_set'] . "</i>)"
-                                : evo()->toDateFormat($content['pub_date'])
+                                : evo()->toDateFormat(entity('pub_date'))
                             ?></td>
                         <td>[*pub_date:date*]</td>
                     </tr>
                     <tr>
                         <td><?= $_lang['page_data_unpublishdate'] ?>:</td>
                         <td><?=
-                            $content['unpub_date'] == 0
+                            entity('unpub_date') == 0
                                 ? "(<i>" . $_lang['not_set'] . "</i>)"
-                                : evo()->toDateFormat($content['unpub_date'])
+                                : evo()->toDateFormat(entity('unpub_date'))
                             ?></td>
                         <td>[*unpub_date:date*]</td>
                     </tr>
                     <tr>
                         <td><?= $_lang['page_data_cacheable'] ?>:</td>
-                        <td><?= $content['cacheable'] == 0 ? $_lang['no'] : $_lang['yes'] ?></td>
+                        <td><?= entity('cacheable') == 0 ? $_lang['no'] : $_lang['yes'] ?></td>
                         <td>[*cacheable*]</td>
                     </tr>
                     <tr>
                         <td><?= $_lang['page_data_searchable'] ?>:</td>
-                        <td><?= $content['searchable'] == 0 ? $_lang['no'] : $_lang['yes'] ?></td>
+                        <td><?= entity('searchable') == 0 ? $_lang['no'] : $_lang['yes'] ?></td>
                         <td>[*searchable*]</td>
                     </tr>
                     <tr>
                         <td><?= $_lang['resource_opt_menu_index'] ?>:</td>
-                        <td><?= $content['menuindex'] ?></td>
+                        <td><?= entity('menuindex') ?></td>
                         <td>[*menuindex*]</td>
                     </tr>
                     <tr>
                         <td><?= $_lang['resource_opt_show_menu'] ?>:</td>
-                        <td><?= $content['hidemenu'] == 1 ? $_lang['no'] : $_lang['yes'] ?></td>
+                        <td><?= entity('hidemenu') == 1 ? $_lang['no'] : $_lang['yes'] ?></td>
                         <td>[*hidemenu*]</td>
                     </tr>
                     <tr>
                         <td><?= $_lang['page_data_web_access'] ?>:</td>
                         <td><?php
-                            if ($content['privateweb'] == 0) {
+                            if (entity('privateweb') == 0) {
                                 echo $_lang['public'];
                             } else {
                                 echo sprintf(
@@ -355,7 +367,7 @@ foreach ($content as $k => $v) {
                     <tr>
                         <td><?= $_lang['page_data_mgr_access'] ?>:</td>
                         <td><?php
-                            if ($content['privatemgr'] == 0) {
+                            if (entity('privatemgr') == 0) {
                                 echo $_lang['public'];
                             } else {
                                 echo sprintf(
@@ -368,12 +380,12 @@ foreach ($content as $k => $v) {
                     </tr>
                     <tr>
                         <td><?= $_lang['page_data_editor'] ?>:</td>
-                        <td><?= $content['richtext'] == 0 ? $_lang['no'] : $_lang['yes'] ?></td>
+                        <td><?= entity('richtext') == 0 ? $_lang['no'] : $_lang['yes'] ?></td>
                         <td>[*richtext*]</td>
                     </tr>
                     <tr>
                         <td><?= $_lang['page_data_folder'] ?>:</td>
-                        <td><?= $content['isfolder'] == 0 ? $_lang['no'] : $_lang['yes'] ?></td>
+                        <td><?= entity('isfolder') == 0 ? $_lang['no'] : $_lang['yes'] ?></td>
                         <td>[*isfolder*]</td>
                     </tr>
                 </table>

--- a/manager/actions/document/mutate_content.dynamic.php
+++ b/manager/actions/document/mutate_content.dynamic.php
@@ -98,7 +98,7 @@ if (config('use_udperms') == 1) {
         $ph['_lang_access_permissions_docs_message'] = lang('access_permissions_docs_message');
         $ph['UDGroups'] = implode("\n", $permissions);
         $body[] = parseText(file_get_tpl('tab_access.tpl'), $ph);
-    } elseif (sessionv('mgrRole') != 1 && $permissions_yes == 0 && $permissions_no > 0
+    } elseif (!manager()->isAdmin() && $permissions_yes == 0 && $permissions_no > 0
         && (
             sessionv('mgrPermissions.access_permissions') == 1
             ||

--- a/manager/actions/document/mutate_content/functions.php
+++ b/manager/actions/document/mutate_content/functions.php
@@ -34,7 +34,7 @@ function getTmplvars($docid, $template_id, $docgrp)
         sprintf(
             "tvtpl.templateid='%s' AND (1='%s' OR ISNULL(tva.documentgroup) %s)",
             $template_id,
-            sessionv('mgrRole'),
+            manager()->isAdmin() ? 1 : 0,
             $docgrp ? sprintf(' OR tva.documentgroup IN (%s)', $docgrp) : ''
         ),
         'tvtpl.rank,tv.rank, tv.id'
@@ -245,6 +245,7 @@ function getUDGroups($id)
             $notPublic = true;
             $inputAttributes['checked'] = 'checked';
         } else {
+            $notPublic = false;
             unset($inputAttributes['checked']);
         }
 
@@ -283,7 +284,7 @@ function getUDGroups($id)
     }
 
     // if mgr user doesn't have access to any of the displayable permissions, forget about them and make doc public
-    if (sessionv('mgrRole') != 1 && !$permissions_yes && $permissions_no) {
+    if (!manager()->isAdmin() && !$permissions_yes && $permissions_no) {
         return [];
     }
 
@@ -585,7 +586,7 @@ function db_value($id, $docgrp)
         sprintf(
             "sc.id='%s' %s",
             $id,
-            (sessionv('mgrRole') == 1 || !$docgrp) ? '' : sprintf(
+            (manager()->isAdmin() || !$docgrp) ? '' : sprintf(
                 'AND (sc.privatemgr=0 OR dg.document_group IN (%s))',
                 $docgrp
             )

--- a/manager/actions/document/mutate_draft.dynamic.php
+++ b/manager/actions/document/mutate_draft.dynamic.php
@@ -111,7 +111,7 @@ if (config('use_udperms') == 1) {
         $ph['UDGroups'] = implode("\n", $permissions);
         $body[] = parseText(file_get_tpl('tab_access.tpl'), $ph);
     } elseif (
-        sessionv('mgrRole') != 1 && $permissions_yes == 0 && $permissions_no > 0
+        !manager()->isAdmin() && $permissions_yes == 0 && $permissions_no > 0
         && (sessionv('mgrPermissions.access_permissions') == 1
             ||
             sessionv('mgrPermissions.web_access_permissions') == 1)

--- a/manager/actions/document/resources_list.static.php
+++ b/manager/actions/document/resources_list.static.php
@@ -41,7 +41,7 @@ $in_docgrp = !empty($docgrp) ? " OR dg.document_group IN (" . $docgrp . ")" : ''
 
 $where = [];
 $where[] = "sc.parent='" . $id . "'";
-if (sessionv('mgrRole') != 1 && !evo()->config['tree_show_protected']) {
+if (!manager()->isAdmin() && !evo()->config['tree_show_protected']) {
     $where[] = sprintf("AND (sc.privatemgr=0 %s)", $in_docgrp);
 }
 $rs = db()->select(
@@ -57,13 +57,13 @@ if (!$numRecords) {
     $children_output = '';
     $f = [];
     $f[] = 'DISTINCT sc.*';
-    if (sessionv('mgrRole') != 1) {
+    if (!manager()->isAdmin()) {
         $f['has_access'] = sprintf('MAX(IF(sc.privatemgr=0 %s, 1, 0))', $in_docgrp);
     }
     $f[] = 'rev.status';
     $where = [];
     $where[] = "sc.parent='" . $id . "'";
-    if (sessionv('mgrRole') != 1 && !evo()->config('tree_show_protected')) {
+    if (!manager()->isAdmin() && !evo()->config('tree_show_protected')) {
         $where[] = sprintf("AND (sc.privatemgr=0 %s)", $in_docgrp);
     }
     $where[] = 'GROUP BY sc.id,rev.status';
@@ -101,7 +101,7 @@ if (!$numRecords) {
             continue;
         }
 
-        if (sessionv('mgrRole') == 1) {
+        if (manager()->isAdmin()) {
             $doc['has_access'] = 1;
         }
         $doc = hsc($doc);
@@ -333,7 +333,7 @@ function getEditedon($editedon)
 
 function getStatusIcon($status)
 {
-    global $modx, $_style;
+    global $_style;
 
     if (!evo()->config['enable_draft']) {
         return '';

--- a/manager/actions/element/files.dynamic.php
+++ b/manager/actions/element/files.dynamic.php
@@ -919,7 +919,7 @@ function webstart_path()
 
 function proteted_path()
 {
-    if (sessionv('mgrRole') == 1) {
+    if (manager()->isAdmin()) {
         return [];
     }
 

--- a/manager/actions/element/mutate_module_resources.dynamic.php
+++ b/manager/actions/element/mutate_module_resources.dynamic.php
@@ -139,7 +139,7 @@ if ($limit < 1) {
 
 $content = db()->getRow($rs);
 $_SESSION['itemname'] = $content['name'];
-if ($content['locked'] == 1 && sessionv('mgrRole') != 1) {
+if ($content['locked'] == 1 && !manager()->isAdmin()) {
     alert()->setError(3);
     alert()->dumpError();
 }

--- a/manager/actions/main/welcome.static.php
+++ b/manager/actions/main/welcome.static.php
@@ -197,9 +197,13 @@ if (config('warning_visibility' == 0 && sessionv('mgrRole') == 1)
     || config('warning_visibility') == 1
 ) {
     include_once(MODX_CORE_PATH . 'config_check.inc.php');
+    $configCheck = new ConfigCheck($_lang);
+    $configCheck->run();
+    $config_check_results = $configCheck->getWarnings();
+
     $modx->setPlaceholder('settings_config', $_lang['warning']);
     $modx->setPlaceholder('configcheck_title', $_lang['configcheck_title']);
-    if ($config_check_results != $_lang['configcheck_ok']) {
+    if ($config_check_results) {
         $modx->setPlaceholder('config_check_results', $config_check_results);
         $modx->setPlaceholder('config_display', 'block');
     } else {

--- a/manager/actions/main/welcome.static.php
+++ b/manager/actions/main/welcome.static.php
@@ -162,7 +162,7 @@ if (evo()->hasPermission('settings')) {
 $modulemenu = [];
 if (evo()->hasPermission('exec_module')) {
     // Each module
-    if (sessionv('mgrRole') != 1) {
+    if (!manager()->isAdmin()) {
         // Display only those modules the user can execute
         $tbl_site_modules = evo()->getFullTableName('site_modules');
         $tbl_site_module_access = evo()->getFullTableName('site_module_access');
@@ -192,7 +192,7 @@ if (0 < count($modulemenu)) {
 $modx->setPlaceholder('Modules', $modules);
 
 // do some config checks
-if (config('warning_visibility' == 0 && sessionv('mgrRole') == 1)
+if (config('warning_visibility' == 0 && manager()->isAdmin())
     || (config('warning_visibility') == 2 && evo()->hasPermission('save_role') == 1)
     || config('warning_visibility') == 1
 ) {

--- a/manager/actions/permission/mutate_user.dynamic.php
+++ b/manager/actions/permission/mutate_user.dynamic.php
@@ -37,9 +37,9 @@ if (manager()->hasFormValues()) {
     $form_v = manager()->loadFormValues();
     // restore post values
     $user = array_merge($user, $form_v);
-    $user['dob'] = ConvertDate($user['dob']);
-    $user['username'] = $user['newusername'];
-    if (is_array($form_v['allowed_days'])) {
+    $user['dob'] = !empty($user['dob']) ? ConvertDate($user['dob']) : '';
+    $user['username'] = $form_v['newusername'] ?? '';
+    if (is_array($form_v['allowed_days']??null)) {
         $user['allowed_days'] = implode(',', $form_v['allowed_days']);
     } else {
         $user['allowed_days'] = '';

--- a/manager/actions/permission/mutate_user/functions.php
+++ b/manager/actions/permission/mutate_user/functions.php
@@ -119,16 +119,16 @@ function blockedmode($user)
         return '0';
     }
 
-    if ($user['blocked'] == 1) {
+    if ($user['blocked']??null == 1) {
         return '1';
     }
-    if ($user['blockeduntil'] && $user['blockeduntil'] > time()) {
+    if ($user['blockeduntil']??null && $user['blockeduntil'] > time()) {
         return '1';
     }
-    if ($user['blockedafter'] && $user['blockedafter'] < time()) {
+    if ($user['blockedafter']??null && $user['blockedafter'] < time()) {
         return '1';
     }
-    if (3 < $user['failedlogins']) {
+    if (isset($user['failedlogins']) && 3 < $user['failedlogins']) {
         return '1';
     }
     return '0';

--- a/manager/frames/nodes.php
+++ b/manager/frames/nodes.php
@@ -68,9 +68,6 @@ function getNodes($indent, $parent = 0, $expandAll=null, $output = '')
         $parent = 0;
     }
 
-    // get document groups for current user
-    $mgrRole = (sessionv('mgrRole')) ? 1 : 0;
-
     // setup spacer
     $spacer = get_spacer($indent);
     $tree_orderby = get_tree_orderby();
@@ -82,19 +79,26 @@ function getNodes($indent, $parent = 0, $expandAll=null, $output = '')
         : ''
     ;
 
-    if (config('tree_show_protected') || sessionv('mgrRole')) {
+    if (config('tree_show_protected') || manager()->isAdmin()) {
         $access = '';
     } else {
         $access = "AND (sc.privatemgr=0 " . $in_docgrp . ")";
     }
-    $field = 'DISTINCT sc.id,pagetitle,menutitle,parent,isfolder,published,deleted,type,menuindex,hidemenu,alias,contentType';
-    $field .= ",privateweb, privatemgr,MAX(IF(1=" . $mgrRole . " OR sc.privatemgr=0 " . $in_docgrp . ", 1, 0)) AS has_access, rev.status AS status";
+    $field = [];
+    $field[] = 'DISTINCT sc.id,pagetitle,menutitle,parent,isfolder,published,deleted';
+    $field[] = 'type,menuindex,hidemenu,alias,contentType,privateweb, privatemgr';
+    if (!manager()->isAdmin()) {
+        $field[] = sprintf('MAX(IF(sc.privatemgr=0 %s, 1, 0)) AS has_access', $in_docgrp);
+    } else {
+        $field[] = '1 AS has_access';
+    }
+    $field[] = 'rev.status AS status';
     $from = '[+prefix+]site_content AS sc';
     $from .= ' LEFT JOIN [+prefix+]document_groups dg on dg.document = sc.id';
     $from .= " LEFT JOIN [+prefix+]site_revision rev on rev.elmid = sc.id AND (rev.status='draft' OR rev.status='standby') AND rev.element='resource'";
     $where = sprintf("parent='%s' %s GROUP BY sc.id,rev.status", $parent, $access);
     $result = db()->select(
-        $field,
+        implode(',', $field),
         $from,
         $where,
         $tree_orderby

--- a/manager/includes/config_check.inc.php
+++ b/manager/includes/config_check.inc.php
@@ -31,7 +31,7 @@ class ConfigCheck {
 ',
                 $this->_lang[$warning['title']],
                 $warning['message'],
-                sessionv('mgrRole') != 1 ? '<br />' . $this->_lang['configcheck_admin'] : ''
+                !manager()->isAdmin() ? '<br />' . $this->_lang['configcheck_admin'] : ''
             );
         }
         $_SESSION['mgrConfigCheck'] = true;

--- a/manager/includes/config_check.inc.php
+++ b/manager/includes/config_check.inc.php
@@ -3,216 +3,51 @@ if (!defined('IN_MANAGER_MODE') || IN_MANAGER_MODE != 'true') {
     exit();
 }
 
-$warnings = [];
-if (ini_get('magic_quotes_gpc')) {
-    $warnings[] = 'magic_quotes_gpc';
-}
-if (!checkAjaxSearch()) {
-    $warnings[] = 'configcheck_danger_ajaxsearch';
-}
-if (!checkConfig()) {
-    $warnings[] = 'configcheck_configinc';
-}
-if (is_file(MODX_BASE_PATH . "assets/templates/manager/login.html")) {
-    $warnings[] = 'configcheck_mgr_tpl';
-}
-if (is_dir('../install/')) {
-    $warnings[] = 'configcheck_installer';
-}
-if (!extension_loaded('gd')) {
-    $warnings[] = 'configcheck_php_gdzip';
-}
-if (!checkValidateReferer()) {
-    $warnings[] = 'configcheck_validate_referer';
-}
-if (!checkActionPhp()) {
-    $warnings[] = 'configcheck_del_actionphp';
-}
-if (!checkTplSwitchPlugin()) {
-    $warnings[] = 'configcheck_templateswitcher_present';
-}
-if (get_sc_value('published', $unauthorized_page) == 0) {
-    $warnings[] = 'configcheck_unauthorizedpage_unpublished';
-}
-if (get_sc_value('published', $error_page) == 0) {
-    $warnings[] = 'configcheck_errorpage_unpublished';
-}
-if (get_sc_value('privateweb', $unauthorized_page) == 1) {
-    $warnings[] = 'configcheck_unauthorizedpage_unavailable';
-}
-if (get_sc_value('privateweb', $error_page) == 1) {
-    $warnings[] = 'configcheck_errorpage_unavailable';
-}
-if (!is_writable(MODX_CACHE_PATH)) {
-    $warnings[] = 'configcheck_cache';
-}
-if (!is_writable(evo()->config('rb_base_dir') . 'images')) {
-    $warnings[] = 'configcheck_images';
-}
-if (!is_dir(evo()->config('rb_base_dir'))) {
-    $warnings[] = 'configcheck_rb_base_dir';
-}
-if (!is_dir(evo()->config('filemanager_path'))) {
-    $warnings[] = 'configcheck_filemanager_path';
-}
-if (sessionv('mgrRole') == 1) {
-    $warnings[] = 'configcheck_you_are_admin';
-}
+class ConfigCheck {
+    private $warnings = '';
+    private $_lang;
+    private $config_check_result = [];
 
-// clear file info cache
-clearstatcache();
-
-if (!$warnings) {
-    $config_check_results = $_lang['configcheck_ok'];
-    return;
-}
-
-foreach ($warnings as $warning) {
-    switch ($warning) {
-        case 'magic_quotes_gpc':
-            $output = 'magic_quotes_gpcが有効になっています。無効にしてください。';
-            break;
-        case 'configcheck_danger_ajaxsearch':
-            $output = $_lang['configcheck_danger_ajaxsearch_msg'];
-            if (!sessionv('mgrConfigCheck')) {
-                evo()->logEvent(
-                    0,
-                    3,
-                    $_lang['configcheck_danger_ajaxsearch_msg'],
-                    $_lang['configcheck_danger_ajaxsearch']
-                );
-            }
-            break;
-        case 'configcheck_configinc';
-            $output = $_lang['configcheck_configinc_msg'];
-            if (!sessionv('mgrConfigCheck')) {
-                evo()->logEvent(
-                    0,
-                    2,
-                    $_lang['configcheck_configinc_msg'],
-                    $_lang[$warning]
-                );
-            }
-            break;
-        case 'configcheck_you_are_admin':
-            $output = $_lang['configcheck_you_are_admin_msg'];
-            break;
-        case 'configcheck_mgr_tpl':
-            $output = evo()->parseText(
-                $_lang['configcheck_mgr_tpl_msg'],
-                [
-                    'path' => urlencode(MODX_BASE_PATH)
-                ]
-            );
-            break;
-        case 'configcheck_installer':
-            $output = $_lang['configcheck_installer_msg'];
-            if (!sessionv('mgrConfigCheck')) {
-                evo()->logEvent(
-                    0,
-                    3,
-                    $_lang['configcheck_installer_msg'],
-                    $_lang[$warning]);
-            }
-            break;
-        case 'configcheck_cache':
-            $output = $_lang['configcheck_cache_msg'];
-            if (!sessionv('mgrConfigCheck')) {
-                evo()->logEvent(
-                    0,
-                    2,
-                    $_lang['configcheck_cache_msg'],
-                    $_lang[$warning]
-                );
-            }
-            break;
-        case 'configcheck_images':
-            $output = $_lang['configcheck_images_msg'];
-            if (!sessionv('mgrConfigCheck')) {
-                evo()->logEvent(
-                    0,
-                    2,
-                    $_lang['configcheck_images_msg'],
-                    $_lang[$warning]
-                );
-            }
-            break;
-        case 'configcheck_rb_base_dir':
-            $output = '$modx->config[\'rb_base_dir\']';
-            break;
-        case 'configcheck_filemanager_path':
-            $output = '$modx->config[\'filemanager_path\']';
-            break;
-        case 'configcheck_lang_difference':
-            $output = $_lang['configcheck_lang_difference_msg'];
-            break;
-        case 'configcheck_php_gdzip':
-            $output = $_lang['configcheck_php_gdzip_msg'];
-            break;
-        case 'configcheck_unauthorizedpage_unpublished':
-            $output = $_lang['configcheck_unauthorizedpage_unpublished_msg'];
-            break;
-        case 'configcheck_errorpage_unpublished':
-            $output = $_lang['configcheck_errorpage_unpublished_msg'];
-            break;
-        case 'configcheck_unauthorizedpage_unavailable':
-            $output = $_lang['configcheck_unauthorizedpage_unavailable_msg'];
-            break;
-        case 'configcheck_errorpage_unavailable':
-            $output = $_lang['configcheck_errorpage_unavailable_msg'];
-            break;
-        case 'configcheck_validate_referer':
-            $msg = $_lang['configcheck_validate_referer_msg'];
-            $msg .= '<br />' . sprintf($_lang["configcheck_hide_warning"], 'validate_referer');
-            $output = '<span id="validate_referer_warning_wrapper">' . $msg . "</span>\n";
-            break;
-        case 'configcheck_del_actionphp':
-            $output = $_lang['configcheck_del_actionphp_msg'];
-            if (!sessionv('mgrConfigCheck')) {
-                evo()->logEvent(
-                    0,
-                    3,
-                    $_lang['configcheck_del_actionphp_msg'],
-                    $_lang[$warning]
-                );
-            }
-            break;
-        case 'configcheck_templateswitcher_present':
-            $msg = $_lang['configcheck_templateswitcher_present_msg'];
-            if (sessionv('mgrPermissions.save_plugin') == 1) {
-                $msg .= '<br />' . $_lang["configcheck_templateswitcher_present_disable"];
-            }
-            if (sessionv('mgrPermissions.delete_plugin') == 1) {
-                $msg .= '<br />' . $_lang["configcheck_templateswitcher_present_delete"];
-            }
-            $msg .= '<br />' . sprintf($_lang["configcheck_hide_warning"], 'templateswitcher_present');
-            $output = '<span id="templateswitcher_present_warning_wrapper">' . $msg . "</span>\n";
-            break;
-        default :
-            $output = $_lang['configcheck_default_msg'];
+    public function __construct($_lang) {
+        $this->_lang = $_lang;
     }
-    $config_check_result[] = sprintf(
-        '<fieldset style="padding:0;">
+
+    public function run() {
+        $warnings = $this->generateWarnings();
+
+        // clear file info cache
+        clearstatcache();
+
+        if (!$warnings) {
+            return $this->_lang['configcheck_ok'];
+        }
+
+        foreach ($warnings as $warning) {
+            $this->config_check_result[] = sprintf(
+                '<fieldset style="padding:0;">
     <p><strong>%s</strong></p>
     <p style="padding-left:1em">%s%s</p>
 </fieldset>
 ',
-        $_lang[$warning],
-        $output,
-        sessionv('mgrRole') != 1 ? '<br />' . $_lang['configcheck_admin'] : ''
-    );
-}
-$_SESSION['mgrConfigCheck'] = true;
-$config_check_results = "<h3>" . $_lang['configcheck_notok'] . "</h3>";
-$config_check_results .= implode("\n", $config_check_result);
+                $this->_lang[$warning['title']],
+                $warning['message'],
+                sessionv('mgrRole') != 1 ? '<br />' . $this->_lang['configcheck_admin'] : ''
+            );
+        }
+        $_SESSION['mgrConfigCheck'] = true;
+        $this->warnings = "<h3>" . $this->_lang['configcheck_notok'] . "</h3>"
+            . implode("\n", $this->config_check_result);
+    }
 
+    public function getWarnings() {
+        return $this->warnings;
+    }
 
-function get_src_TemplateSwitcher_js($tplName)
-{
-    global $_lang;
+    private function get_src_TemplateSwitcher_js($tplName) {
+        global $_lang;
 
-    $script =
-        ">
+        $script =
+            ">
 function deleteTemplateSwitcher(){
     if(confirm('" . $_lang["confirm_delete_plugin"] . "')) {
 	\$j.post('index.php',{'a':'118','action':'updateplugin','key':'_delete_','lang':'" . $tplName . "'},function(resp)
@@ -229,107 +64,279 @@ function disableTemplateSwitcher(){
     });
 }
 </script>";
-    return $script;
-}
-
-function get_sc_value($field, $id)
-{
-    if (empty($id)) {
-        return true;
-    }
-    return db()->getValue(
-        db()->select(
-            $field,
-            '[+prefix+]site_content',
-            sprintf("id='%s'", $id)
-        )
-    );
-}
-
-function checkAjaxSearch()
-{
-    $target_path = MODX_BASE_PATH . 'assets/snippets/ajaxSearch/classes/ajaxSearchConfig.class.inc.php';
-    if (!is_file($target_path)) {
-        return true;
-    }
-    if (strpos(file_get_contents($target_path), 'remove any @BINDINGS') !== false) {
-        return true;
+        return $script;
     }
 
-    return false;
-}
-
-function checkConfig()
-{
-    if (!is_writable(MODX_CORE_PATH . 'config.inc.php')) {
-        return true;
-    }
-    if (chmod(MODX_CORE_PATH . 'config.inc.php', 0444)) {
-        return true;
-    }
-    return false;
-}
-
-function checkValidateReferer()
-{
-    if (evo()->config('_hide_configcheck_validate_referer')) {
-        return true;
-    }
-    if (sessionv('mgrPermissions.settings') != 1) {
-        return true;
-    }
-    $rs = db()->select(
-        'setting_value',
-        '[+prefix+]system_settings',
-        "setting_name='validate_referer' AND setting_value=0"
-    );
-    if (!db()->count($rs)) {
-        return true;
-    }
-    return false;
-}
-
-function checkActionPhp()
-{
-    $actionphp = MODX_BASE_PATH . 'action.php';
-    if (!is_file($actionphp)) {
-        return true;
-    }
-    $src = file_get_contents($actionphp);
-    if (strpos($src, 'if(strpos($path,MODX_MANAGER_PATH)!==0)') !== false) {
-        return true;
-    }
-    return false;
-}
-
-// check for Template Switcher plugin
-function checkTplSwitchPlugin()
-{
-    if (evo()->config('_hide_configcheck_templateswitcher_present')) {
-        return true;
-    }
-    if (!sessionv('mgrPermissions.edit_plugin')) {
-        return true;
-    }
-    if (sessionv('mgrPermissions.edit_plugin') != 1) {
-        return true;
-    }
-    $rs = db()->select(
-        'name, disabled',
-        '[+prefix+]site_plugins',
-        [
-            "name IN ('TemplateSwitcher','Template Switcher','templateswitcher','template_switcher','template switcher')",
-            "OR plugincode LIKE '%TemplateSwitcher%'"
-        ]
-    );
-    while ($row = db()->getRow($rs)) {
-        if ($row['disabled'] != 0) {
-            continue;
+    private function get_sc_value($field, $id) {
+        if (empty($id)) {
+            return true;
         }
-        evo()->regClientScript(
-            get_src_TemplateSwitcher_js($row['name'])
+        return db()->getValue(
+            db()->select(
+                $field,
+                '[+prefix+]site_content',
+                sprintf("id='%s'", $id)
+            )
         );
+    }
+
+    private function checkAjaxSearch() {
+        $target_path = MODX_BASE_PATH . 'assets/snippets/ajaxSearch/classes/ajaxSearchConfig.class.inc.php';
+        if (!is_file($target_path)) {
+            return true;
+        }
+        if (strpos(file_get_contents($target_path), 'remove any @BINDINGS') !== false) {
+            return true;
+        }
+
         return false;
     }
-    return true;
+
+    private function checkConfig() {
+        if (!is_writable(MODX_CORE_PATH . 'config.inc.php')) {
+            return true;
+        }
+        if (chmod(MODX_CORE_PATH . 'config.inc.php', 0444)) {
+            return true;
+        }
+        return false;
+    }
+
+    private function checkValidateReferer() {
+        if (evo()->config('_hide_configcheck_validate_referer')) {
+            return true;
+        }
+        if (sessionv('mgrPermissions.settings') != 1) {
+            return true;
+        }
+        $rs = db()->select(
+            'setting_value',
+            '[+prefix+]system_settings',
+            "setting_name='validate_referer' AND setting_value=0"
+        );
+        if (!db()->count($rs)) {
+            return true;
+        }
+        return false;
+    }
+
+    private function checkActionPhp() {
+        $actionphp = MODX_BASE_PATH . 'action.php';
+        if (!is_file($actionphp)) {
+            return true;
+        }
+        $src = file_get_contents($actionphp);
+        if (strpos($src, 'if(strpos($path,MODX_MANAGER_PATH)!==0)') !== false) {
+            return true;
+        }
+        return false;
+    }
+
+    private function checkTplSwitchPlugin() {
+        if (evo()->config('_hide_configcheck_templateswitcher_present')) {
+            return true;
+        }
+        if (!sessionv('mgrPermissions.edit_plugin')) {
+            return true;
+        }
+        if (sessionv('mgrPermissions.edit_plugin') != 1) {
+            return true;
+        }
+        $rs = db()->select(
+            'name, disabled',
+            '[+prefix+]site_plugins',
+            [
+                "name IN ('TemplateSwitcher','Template Switcher','templateswitcher','template_switcher','template switcher')",
+                "OR plugincode LIKE '%TemplateSwitcher%'"
+            ]
+        );
+        while ($row = db()->getRow($rs)) {
+            if ($row['disabled'] != 0) {
+                continue;
+            }
+            evo()->regClientScript(
+                $this->get_src_TemplateSwitcher_js($row['name'])
+            );
+            return false;
+        }
+        return true;
+    }
+
+    private function generateWarnings() {
+        $warnings = [];
+
+        if (!$this->checkAjaxSearch()) {
+            $output = $this->_lang['configcheck_danger_ajaxsearch_msg'];
+            if (!sessionv('mgrConfigCheck')) {
+                evo()->logEvent(
+                    0,
+                    3,
+                    $this->_lang['configcheck_danger_ajaxsearch_msg'],
+                    $this->_lang['configcheck_danger_ajaxsearch']
+                );
+            }
+            $warnings[] = [
+                'title' => 'configcheck_danger_ajaxsearch',
+                'message' => $output
+            ];
+        }
+
+        if (!$this->checkConfig()) {
+            $output = $this->_lang['configcheck_configinc_msg'];
+            if (!sessionv('mgrConfigCheck')) {
+                evo()->logEvent(
+                    0,
+                    2,
+                    $this->_lang['configcheck_configinc_msg'],
+                    $this->_lang['configcheck_configinc']
+                );
+            }
+            $warnings[] = [
+                'title' => 'configcheck_configinc',
+                'message' => $output
+            ];
+        }
+
+        if (is_file(MODX_BASE_PATH . "assets/templates/manager/login.html")) {
+            $warnings[] = [
+                'title' => 'configcheck_mgr_tpl',
+                'message' => evo()->parseText(
+                    $this->_lang['configcheck_mgr_tpl_msg'],
+                    [
+                        'path' => urlencode(MODX_BASE_PATH)
+                    ]
+                )
+            ];
+        }
+
+        if (is_dir('../install/')) {
+            $output = $this->_lang['configcheck_installer_msg'];
+            if (!sessionv('mgrConfigCheck')) {
+                evo()->logEvent(
+                    0,
+                    3,
+                    $this->_lang['configcheck_installer_msg'],
+                    $this->_lang['configcheck_installer']
+                );
+            }
+            $warnings[] = [
+                'title' => 'configcheck_installer',
+                'message' => $output
+            ];
+        }
+
+        if (!extension_loaded('gd')) {
+            $warnings[] = [
+                'title' => 'configcheck_php_gdzip',
+                'message' => $this->_lang['configcheck_php_gdzip_msg']
+            ];
+        }
+
+        if (!$this->checkValidateReferer()) {
+            $msg = $this->_lang['configcheck_validate_referer_msg'];
+            $msg .= '<br />' . sprintf($this->_lang["configcheck_hide_warning"], 'validate_referer');
+            $warnings[] = [
+                'title' => 'configcheck_validate_referer',
+                'message' => '<span id="validate_referer_warning_wrapper">' . $msg . "</span>\n"
+            ];
+        }
+
+        if (!$this->checkActionPhp()) {
+            $output = $this->_lang['configcheck_del_actionphp_msg'];
+            if (!sessionv('mgrConfigCheck')) {
+                evo()->logEvent(
+                    0,
+                    3,
+                    $this->_lang['configcheck_del_actionphp_msg'],
+                    $this->_lang['configcheck_del_actionphp']
+                );
+            }
+            $warnings[] = [
+                'title' => 'configcheck_del_actionphp',
+                'message' => $output
+            ];
+        }
+
+        if (!$this->checkTplSwitchPlugin()) {
+            $msg = $this->_lang['configcheck_templateswitcher_present_msg'];
+            if (sessionv('mgrPermissions.save_plugin') == 1) {
+                $msg .= '<br />' . $this->_lang["configcheck_templateswitcher_present_disable"];
+            }
+            if (sessionv('mgrPermissions.delete_plugin') == 1) {
+                $msg .= '<br />' . $this->_lang["configcheck_templateswitcher_present_delete"];
+            }
+            $msg .= '<br />' . sprintf($this->_lang["configcheck_hide_warning"], 'templateswitcher_present');
+            $warnings[] = [
+                'title' => 'configcheck_templateswitcher_present',
+                'message' => '<span id="templateswitcher_present_warning_wrapper">' . $msg . "</span>\n"
+            ];
+        }
+
+        if ($this->get_sc_value('published', config('unauthorized_page')) == 0) {
+            $warnings[] = [
+                'title' => 'configcheck_unauthorizedpage_unpublished',
+                'message' => $this->_lang['configcheck_unauthorizedpage_unpublished_msg']
+            ];
+        }
+
+        if ($this->get_sc_value('published', config('error_page')) == 0) {
+            $warnings[] = [
+                'title' => 'configcheck_errorpage_unpublished',
+                'message' => $this->_lang['configcheck_errorpage_unpublished_msg']
+            ];
+        }
+
+        if ($this->get_sc_value('privateweb', config('unauthorized_page')) == 1) {
+            $warnings[] = [
+                'title' => 'configcheck_unauthorizedpage_unavailable',
+                'message' => $this->_lang['configcheck_unauthorizedpage_unavailable_msg']
+            ];
+        }
+
+        if ($this->get_sc_value('privateweb', config('error_page')) == 1) {
+            $warnings[] = [
+                'title' => 'configcheck_errorpage_unavailable',
+                'message' => $this->_lang['configcheck_errorpage_unavailable_msg']
+            ];
+        }
+
+        if (!is_writable(MODX_CACHE_PATH)) {
+            $warnings[] = [
+                'title' => 'configcheck_cache',
+                'message' => $this->_lang['configcheck_cache_msg']
+            ];
+        }
+
+        if (!is_writable(evo()->config('rb_base_dir') . 'images')) {
+            $warnings[] = [
+                'title' => 'configcheck_images',
+                'message' => $this->_lang['configcheck_images_msg']
+            ];
+        }
+
+        if (!is_dir(evo()->config('rb_base_dir'))) {
+            $warnings[] = [
+                'title' => 'configcheck_rb_base_dir',
+                'message' => '$modx->config[\'rb_base_dir\']'
+            ];
+        }
+        if (!is_dir(evo()->config('filemanager_path'))) {
+            $warnings[] = [
+                'title' => 'configcheck_filemanager_path',
+                'message' => '$modx->config[\'filemanager_path\']'
+            ];
+        }
+
+        if (sessionv('mgrRole') == 1) {
+            $warnings[] = [
+                'title' => 'configcheck_you_are_admin',
+                'message' => $this->_lang['configcheck_you_are_admin_msg']
+            ];
+        }
+
+        return $warnings;
+    }
 }
+
+$configCheck = new ConfigCheck($_lang);
+$config_check_results = $configCheck->run();

--- a/manager/includes/config_check.inc.php
+++ b/manager/includes/config_check.inc.php
@@ -52,7 +52,7 @@ if (!is_writable(evo()->config('rb_base_dir') . 'images')) {
 if (!is_dir(evo()->config('rb_base_dir'))) {
     $warnings[] = 'configcheck_rb_base_dir';
 }
-if (!is_dir(evo()->config['filemanager_path'])) {
+if (!is_dir(evo()->config('filemanager_path'))) {
     $warnings[] = 'configcheck_filemanager_path';
 }
 if (sessionv('mgrRole') == 1) {

--- a/manager/includes/extenders/dbapi/mysqli.inc.php
+++ b/manager/includes/extenders/dbapi/mysqli.inc.php
@@ -97,7 +97,8 @@ class DBAPI
         if ($dbase) {
             $this->dbase = trim($dbase, '`');
         }
-        $this->dbase = trim($this->dbase, '`');
+
+        $this->dbase = $this->dbase ? trim($this->dbase, '`') : '';
 
         if (substr(PHP_OS, 0, 3) === 'WIN' && $this->hostname === 'localhost') {
             $hostname = '127.0.0.1';

--- a/manager/includes/extenders/ex_managerapi.php
+++ b/manager/includes/extenders/ex_managerapi.php
@@ -536,6 +536,19 @@ class ManagerAPI
         );
     }
 
+    public function isAdmin()
+    {
+        if (!hasPermission('access_permissions')) {
+            return false;
+        }
+
+        if (!hasPermission('web_access_permissions')) {
+            return false;
+        }
+
+        return true;
+    }
+
     function getMessageCount()
     {
         if (!evo()->hasPermission('messages')) {

--- a/manager/includes/extenders/ex_managerapi.php
+++ b/manager/includes/extenders/ex_managerapi.php
@@ -81,7 +81,7 @@ class ManagerAPI
         $values = sessionv('mgrFormValues', []);
         unset($_SESSION['mgrFormValues']);
 
-        return $values;
+        return $values[$this->action];
     }
 
     function get_alias_from_title($id = 0, $pagetitle = '')

--- a/manager/processors/document/save_resource.processor.php
+++ b/manager/processors/document/save_resource.processor.php
@@ -332,7 +332,7 @@ function _check_duplicate_alias($id, $alias, $parent)
 
 function checkDocPermission($id, $document_groups = [])
 {
-    if (sessionv('mgrRole') != 1 && is_array($document_groups) && $document_groups) {
+    if (!manager()->isAdmin() && is_array($document_groups) && $document_groups) {
         $document_group_list = implode(',', array_filter($document_groups, 'is_numeric'));
         if ($document_group_list) {
             $count = db()->getValue(

--- a/manager/processors/module/execute_module.processor.php
+++ b/manager/processors/module/execute_module.processor.php
@@ -24,7 +24,7 @@ if (!is_numeric($id)) {
 }
 
 // check if user has access permission, except admins
-if (sessionv('mgrRole') != 1) {
+if (!manager()->isAdmin()) {
     $userid = evo()->getLoginUserID();
     $sql = sprintf("SELECT sma.usergroup,mg.member FROM %s sma LEFT JOIN %s mg ON mg.user_group = sma.usergroup AND member='%s'WHERE sma.module = '%s'",
         $tbl_site_module_access,

--- a/manager/processors/permission/save_user.functions.php
+++ b/manager/processors/permission/save_user.functions.php
@@ -152,7 +152,7 @@ function generate_password($length = 10)
 
 function verifyPermission()
 {
-    if (sessionv('mgrRole') == 1) {
+    if (manager()->isAdmin()) {
         return true;
     }
     if (evo()->input_post('role') != 1) {

--- a/manager/processors/permission/save_user.processor.php
+++ b/manager/processors/permission/save_user.processor.php
@@ -87,7 +87,7 @@ if (in_array(postv('mode'), [12, 74])) {
             exit;
         }
     }
-    if (sessionv('mgrRole') != 1 && role_byuserid(postv('userid')) == 1) {
+    if (!manager()->isAdmin() && role_byuserid(postv('userid')) == 1) {
         webAlert('You cannot alter an administrative user.');
         exit;
     }


### PR DESCRIPTION
This pull request includes several changes aimed at improving code readability and maintainability by replacing direct role checks with a more intuitive method call for checking admin status. Additionally, a new helper function has been introduced to streamline data access.

Key changes include:

### Code Simplification and Readability:

* Replaced direct role checks (`sessionv('mgrRole') == 1`) with the `manager()->isAdmin()` method to improve readability and maintainability. This change affects multiple files, including `manager/actions/document/document_data.static.php`, `manager/actions/document/mutate_content.functions.php`, and others. [[1]](diffhunk://#diff-6fc60ac6e3d955c35646d516615a95fda2509f1905bdea4643c78820f710b8ceL32-R32) [[2]](diffhunk://#diff-6fc60ac6e3d955c35646d516615a95fda2509f1905bdea4643c78820f710b8ceL83-R91) [[3]](diffhunk://#diff-58b12aee01d3c6e3f57c51731f064f3b10854fa631fb328bee87b3451be89244L101-R101) [[4]](diffhunk://#diff-47ee1edbc67acc9c3da71a1a36accb3c1cdd1598ee1984478f04c8206c819f33L37-R37) [[5]](diffhunk://#diff-57b775f08486c708fcf8beecf494a011ac980154e6caa948e2e1a35c36810d12L114-R114) [[6]](diffhunk://#diff-a77473b6657b03e3ab5c592c15845df49bcd0ba1d8dfa08f4977ce55f134fdc3L44-R44) [[7]](diffhunk://#diff-d18d0bdbfe7d3e43f52e6bb17706e5d83e53e10c609ef0bf584eb1f6196cf4dfL922-R922) [[8]](diffhunk://#diff-3e249515a7a03539c67efead718912be15e0394a2fdc39e83d7a058191892b13L142-R142)

### Introduction of Helper Function:

* Introduced the `entity($key, $default = null)` helper function in `manager/actions/document/document_data.static.php` to streamline data access and reduce code duplication. This function is used extensively throughout the file to replace direct array access.

### Specific Updates in `document_data.static.php`:

* Updated various sections to use the new `entity` function for accessing content data, improving code consistency. This includes changes in the `movedocument` function and other parts of the file. [[1]](diffhunk://#diff-6fc60ac6e3d955c35646d516615a95fda2509f1905bdea4643c78820f710b8ceL173-R185) [[2]](diffhunk://#diff-6fc60ac6e3d955c35646d516615a95fda2509f1905bdea4643c78820f710b8ceL206-R218) [[3]](diffhunk://#diff-6fc60ac6e3d955c35646d516615a95fda2509f1905bdea4643c78820f710b8ceL215-R242) [[4]](diffhunk://#diff-6fc60ac6e3d955c35646d516615a95fda2509f1905bdea4643c78820f710b8ceL240-R270) [[5]](diffhunk://#diff-6fc60ac6e3d955c35646d516615a95fda2509f1905bdea4643c78820f710b8ceL267-R280) [[6]](diffhunk://#diff-6fc60ac6e3d955c35646d516615a95fda2509f1905bdea4643c78820f710b8ceL277-R289) [[7]](diffhunk://#diff-6fc60ac6e3d955c35646d516615a95fda2509f1905bdea4643c78820f710b8ceL287-R299) [[8]](diffhunk://#diff-6fc60ac6e3d955c35646d516615a95fda2509f1905bdea4643c78820f710b8ceL296-R308) [[9]](diffhunk://#diff-6fc60ac6e3d955c35646d516615a95fda2509f1905bdea4643c78820f710b8ceL305-R355) [[10]](diffhunk://#diff-6fc60ac6e3d955c35646d516615a95fda2509f1905bdea4643c78820f710b8ceL358-R370) [[11]](diffhunk://#diff-6fc60ac6e3d955c35646d516615a95fda2509f1905bdea4643c78820f710b8ceL371-R388)

These changes collectively enhance the maintainability and readability of the codebase, making it easier to understand and modify in the future.This pull request includes a small change to the `manager/includes/extenders/dbapi/mysqli.inc.php` file. The change ensures that the `$this->dbase` variable is properly trimmed of backticks or set to an empty string if it is not already set.

* [`manager/includes/extenders/dbapi/mysqli.inc.php`](diffhunk://#diff-5aaf03fe1813de84748955299416f5faeba87c82dc59643b0a969c415827ed71L100-R101): Modified the assignment of `$this->dbase` to ensure it is trimmed of backticks or set to an empty string if not set.

-----------------------------
このプルリクエストには、コードの可読性と保守性を向上させるためのいくつかの変更が含まれています。これには、管理者権限の確認に関する直接的な役割チェックを、より直感的なメソッド呼び出しに置き換えることや、データアクセスを簡素化するための新しいヘルパー関数の導入が含まれます。

### コードの簡素化と可読性の向上

- 管理者権限の確認で使用されていた直接的な役割チェック（例: `sessionv('mgrRole') == 1`）を、可読性と保守性を向上させるために、`manager()->isAdmin()` メソッドに置き換えました。この変更は以下のファイルに影響します：
  - `manager/actions/document/document_data.static.php`
  - `manager/actions/document/mutate_content.functions.php`  
  他、多数のファイルで反映されています。[[[1]](diffhunk://#diff-6fc60ac6e3d955c35646d516615a95fda2509f1905bdea4643c78820f710b8ceL32-R32)](diffhunk://#diff-6fc60ac6e3d955c35646d516615a95fda2509f1905bdea4643c78820f710b8ceL32-R32) [[[2]](diffhunk://#diff-6fc60ac6e3d955c35646d516615a95fda2509f1905bdea4643c78820f710b8ceL83-R91)](diffhunk://#diff-6fc60ac6e3d955c35646d516615a95fda2509f1905bdea4643c78820f710b8ceL83-R91) [[[3]](diffhunk://#diff-58b12aee01d3c6e3f57c51731f064f3b10854fa631fb328bee87b3451be89244L101-R101)](diffhunk://#diff-58b12aee01d3c6e3f57c51731f064f3b10854fa631fb328bee87b3451be89244L101-R101) [[[4]](diffhunk://#diff-47ee1edbc67acc9c3da71a1a36accb3c1cdd1598ee1984478f04c8206c819f33L37-R37)](diffhunk://#diff-47ee1edbc67acc9c3da71a1a36accb3c1cdd1598ee1984478f04c8206c819f33L37-R37)

### ヘルパー関数の導入

- データアクセスを簡素化し、コードの重複を減らすために、`entity($key, $default = null)` ヘルパー関数を `manager/actions/document/document_data.static.php` に導入しました。この関数はファイル全体で広く使用されています。

### `document_data.static.php` の具体的な更新内容

- 新しい `entity` 関数を使用して、コンテンツデータへのアクセスを統一し、コードの一貫性を向上させました。この更新は以下の箇所に適用されています：
  - `movedocument` 関数内
  - その他のセクション  
  [[[1]](diffhunk://#diff-6fc60ac6e3d955c35646d516615a95fda2509f1905bdea4643c78820f710b8ceL173-R185)](diffhunk://#diff-6fc60ac6e3d955c35646d516615a95fda2509f1905bdea4643c78820f710b8ceL173-R185) [[[2]](diffhunk://#diff-6fc60ac6e3d955c35646d516615a95fda2509f1905bdea4643c78820f710b8ceL206-R218)](diffhunk://#diff-6fc60ac6e3d955c35646d516615a95fda2509f1905bdea4643c78820f710b8ceL206-R218) [[[3]](diffhunk://#diff-6fc60ac6e3d955c35646d516615a95fda2509f1905bdea4643c78820f710b8ceL215-R242)](diffhunk://#diff-6fc60ac6e3d955c35646d516615a95fda2509f1905bdea4643c78820f710b8ceL215-R242) [[[4]](diffhunk://#diff-6fc60ac6e3d955c35646d516615a95fda2509f1905bdea4643c78820f710b8ceL240-R270)](diffhunk://#diff-6fc60ac6e3d955c35646d516615a95fda2509f1905bdea4643c78820f710b8ceL240-R270)

### `mysqli.inc.php` ファイルの小さな変更

- `$this->dbase` 変数がバッククォートで囲まれている場合、それをトリムし、値が設定されていない場合は空文字列に設定するように変更しました。  
  - [`[manager/includes/extenders/dbapi/mysqli.inc.php](diffhunk://#diff-5aaf03fe1813de84748955299416f5faeba87c82dc59643b0a969c415827ed71L100-R101)`](diffhunk://#diff-5aaf03fe1813de84748955299416f5faeba87c82dc59643b0a969c415827ed71L100-R101)  

これらの変更により、コードベースの保守性と可読性が向上し、今後の理解と変更が容易になります。