### PR TITLE
fix: refactor access control logic and add isAdmin method for improve…

### DIFF
--- a/manager/includes/extenders/ex_managerapi.php
+++ b/manager/includes/extenders/ex_managerapi.php
@@ -540,6 +540,19 @@ class ManagerAPI
         );
     }
 
+    public function isAdmin()
+    {
+        if (!hasPermission('access_permissions')) {
+            return false;
+        }
+
+        if (!hasPermission('web_access_permissions')) {
+            return false;
+        }
+
+        return true;
+    }
+
     function getMessageCount()
     {
         if (!evo()->hasPermission('messages')) {


### PR DESCRIPTION
…d clarity and functionality
This pull request includes several changes aimed at improving the functionality and security of the `manager` module by refactoring the code and adding a new method to check for admin permissions.

Refactoring and security improvements:

* [`manager/frames/nodes.php`](diffhunk://#diff-7b11707e2b50b3c0075fec2a971ef673850eab50a0644de109e9cae1dff1be6eL71-L73): Removed the `$mgrRole` variable and replaced the direct session check with a call to the new `isAdmin` method to determine if the current user is an admin. This change enhances security by centralizing the admin check logic. [[1]](diffhunk://#diff-7b11707e2b50b3c0075fec2a971ef673850eab50a0644de109e9cae1dff1be6eL71-L73) [[2]](diffhunk://#diff-7b11707e2b50b3c0075fec2a971ef673850eab50a0644de109e9cae1dff1be6eL85-R101)

New method for admin check:

* [`manager/includes/extenders/ex_managerapi.php`](diffhunk://#diff-e26de80f47df5496d3c108aed9be6d4d479de24ff4b48fac366c189d536d7682R543-R555): Added a new method `isAdmin` to check for admin permissions by verifying access to both `access_permissions` and `web_access_permissions`. This method is used to replace the previous session-based admin check, improving code readability and maintainability.