### PR TITLE
fix

### DIFF
--- a/manager/includes/document.parser.class.inc.php
+++ b/manager/includes/document.parser.class.inc.php
@@ -41,6 +41,7 @@ class DocumentParser
     public $executedQueries;
     public $queryTime;
     public $currentSnippet;
+    public $currentSnippetCode;
     public $aliases;
     public $entrypage;
     public $dumpSQL;
@@ -165,7 +166,7 @@ class DocumentParser
             ini_set('display_errors', 1);
         }
         if (!defined('MODX_SETUP_PATH')) {
-            set_error_handler([&$this, 'phpError'], E_ALL); //error_reporting(0);
+            set_error_handler([&$this, 'phpError'], E_ALL & ~E_NOTICE); //error_reporting(0);
         }
         mb_internal_encoding('utf-8');
         $this->loadExtension('DBAPI'); // load DBAPI class
@@ -2716,8 +2717,10 @@ class DocumentParser
 
     public function evalSnippet($phpcode, $params)
     {
+        $this->currentSnippetCode = $phpcode;
         $phpcode = trim($phpcode);
         if (empty($phpcode)) {
+            $this->currentSnippetCode = '';
             return '';
         }
 

--- a/manager/includes/extenders/ex_subparser.php
+++ b/manager/includes/extenders/ex_subparser.php
@@ -352,6 +352,17 @@ class SubParser
                     'right' => $source
                 ]
             );
+        } elseif ($modx->currentSnippetCode) {
+            $lines = explode("\n", $modx->currentSnippetCode);
+            $str .= $modx->parseText(
+                $tpl,
+                [
+                    'left' => 'Source : ',
+                    'right' => sprintf(
+                        '[[%s]]: %s', $modx->currentSnippet, $lines[$line - 1]
+                    )
+                ]
+            );
         }
 
         if (db()->lastQuery) {
@@ -403,16 +414,6 @@ class SubParser
                             $resource['pagetitle']
                         )
                     )
-                ]
-            );
-        }
-
-        if ($modx->currentSnippet) {
-            $str .= $modx->parseText(
-                $tpl,
-                [
-                    'left' => 'Current Snippet : ',
-                    'right' => $modx->currentSnippet
                 ]
             );
         }

--- a/manager/includes/extenders/ex_subparser.php
+++ b/manager/includes/extenders/ex_subparser.php
@@ -172,30 +172,28 @@ class SubParser
             $title = 'DB connect error';
         }
         $modx->db->lastQuery = $_;
-        if (isset($modx->config['send_errormail']) && $modx->config['send_errormail'] !== '0') {
-            if ($modx->config['send_errormail'] <= $type) {
-                $body['URL'] = MODX_SITE_URL . ltrim(evo()->server('REQUEST_URI'), '/');
-                $body['Source'] = $fields['source'];
-                $body['IP'] = evo()->server('REMOTE_ADDR');
-                if (evo()->server('REMOTE_ADDR')) {
-                    $hostname = gethostbyaddr(evo()->server('REMOTE_ADDR'));
-                }
-                if ($hostname) {
-                    $body['Host name'] = $hostname;
-                }
-                if ($modx->event->activePlugin) {
-                    $body['Plugin'] = $modx->event->activePlugin;
-                }
-                if ($modx->currentSnippet) {
-                    $body['Snippet'] = $modx->currentSnippet;
-                }
-                $subject = 'Error mail from ' . $modx->config['site_name'];
-                foreach ($body as $k => $v) {
-                    $mailbody[] = sprintf('[%s] %s', $k, $v);
-                }
-                $mailbody = implode("\n", $mailbody);
-                $modx->sendmail($subject, $mailbody);
+        if (config('send_errormail') && config('send_errormail') <= $type) {
+            $body['URL'] = MODX_SITE_URL . ltrim(evo()->server('REQUEST_URI'), '/');
+            $body['Source'] = $fields['source'];
+            $body['IP'] = evo()->server('REMOTE_ADDR');
+            if (evo()->server('REMOTE_ADDR')) {
+                $hostname = gethostbyaddr(evo()->server('REMOTE_ADDR'));
             }
+            if ($hostname) {
+                $body['Host name'] = $hostname;
+            }
+            if ($modx->event->activePlugin) {
+                $body['Plugin'] = $modx->event->activePlugin;
+            }
+            if ($modx->currentSnippet) {
+                $body['Snippet'] = $modx->currentSnippet;
+            }
+            $subject = 'Error mail from ' . $modx->config['site_name'];
+            foreach ($body as $k => $v) {
+                $mailbody[] = sprintf('[%s] %s', $k, $v);
+            }
+            $mailbody = implode("\n", $mailbody);
+            $modx->sendmail($subject, $mailbody);
         }
         if (!isset($insert_id) || !$insert_id) {
             exit('Error while inserting event log into database.');

--- a/manager/includes/extenders/ex_subparser.php
+++ b/manager/includes/extenders/ex_subparser.php
@@ -273,8 +273,8 @@ class SubParser
 
         $version = globalv('version', '');
         $release_date = globalv('release_date', '');
-        $ua = hsc(serverv('HTTP_USER_AGENT'));
-        $referer = hsc(serverv('HTTP_REFERER'));
+        $ua = hsc(serverv('HTTP_USER_AGENT', ''));
+        $referer = hsc(serverv('HTTP_REFERER', ''));
         if ($is_error) {
             $str = '<h3 style="color:red">&laquo; MODX Parse Error &raquo;</h3>
                     <table border="0" cellpadding="1" cellspacing="0">

--- a/manager/includes/extenders/ex_subparser.php
+++ b/manager/includes/extenders/ex_subparser.php
@@ -267,6 +267,10 @@ class SubParser
     {
         global $modx;
 
+        if (!$modx->error_reporting && !$modx->isLoggedIn()) {
+            return true;
+        }
+
         $version = globalv('version', '');
         $release_date = globalv('release_date', '');
         $ua = hsc(serverv('HTTP_USER_AGENT'));
@@ -503,9 +507,6 @@ class SubParser
                 $error_level = 3;
         }
         $modx->logEvent(0, $error_level, $str, $title);
-        if ($modx->error_reporting === '99' && !isset($_SESSION['mgrValidated'])) {
-            return true;
-        }
 
         // Set 500 response header
         if (2 < $error_level && $modx->event->name !== 'OnWebPageComplete') {


### PR DESCRIPTION
This pull request includes several changes to the `manager/includes/document.parser.class.inc.php` and `manager/includes/extenders/ex_subparser.php` files to improve error handling and logging. The most important changes include adding a new property to the `DocumentParser` class, updating error handling in the constructor, and modifying the `messageQuit` function to handle snippet code more effectively.

### Enhancements to `DocumentParser` class:

* Added a new property `currentSnippetCode` to the `DocumentParser` class to store the current snippet code.
* Updated the constructor to exclude `E_NOTICE` from error handling, reducing unnecessary notices.
* Modified the `evalSnippet` method to set `currentSnippetCode` to the provided PHP code or clear it if the code is empty.

### Improvements to error handling and logging:

* Updated the `logEvent` function to use a more concise configuration check for sending error emails.
* Enhanced the `messageQuit` function to return early if error reporting is disabled and the user is not logged in, and to include snippet code in the error message if available. [[1]](diffhunk://#diff-676a475695ee323f4e7e755b936180ae6b3fb8e89b65287de952e42ff232de57R268-R275) [[2]](diffhunk://#diff-676a475695ee323f4e7e755b936180ae6b3fb8e89b65287de952e42ff232de57R355-R365) [[3]](diffhunk://#diff-676a475695ee323f4e7e755b936180ae6b3fb8e89b65287de952e42ff232de57L408-L417) [[4]](diffhunk://#diff-676a475695ee323f4e7e755b936180ae6b3fb8e89b65287de952e42ff232de57L506-L508)