### PR TITLE
Fix QuickManager modal closing behaviour

### DIFF
--- a/assets/plugins/qm/inc/on_doc_form_save.php
+++ b/assets/plugins/qm/inc/on_doc_form_save.php
@@ -18,5 +18,5 @@ evo()->sendRedirect(
     evo()->makeUrl(postv('qmrefresh', $id), '', 'quickmanagerclose=1', 'full'),
     0,
     'REDIRECT_HEADER',
-    'HTTP/1.1 301 Moved Permanently'
+    'HTTP/1.1 303 See Other'
 );

--- a/assets/plugins/qm/inc/on_web_page_prerender.php
+++ b/assets/plugins/qm/inc/on_web_page_prerender.php
@@ -19,7 +19,46 @@ $output = &evo()->documentOutput;
 if (getv('quickmanagerclose')) {
     // Set url to refresh
     $url = evo()->makeUrl($docID, '', '', 'full');
-    exit(sprintf("<script>parent.location.href='%s';</script>", $url));
+    $jsonUrl = json_encode($url, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+    exit(<<<HTML
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="utf-8">
+    <title>Reloading…</title>
+</head>
+<body>
+<script>
+(function () {
+    var target = {$jsonUrl};
+    var parentWindow = null;
+    try {
+        parentWindow = window.parent;
+    } catch (e) {}
+
+    if (parentWindow && parentWindow !== window) {
+        try {
+            if (parentWindow.jQuery && parentWindow.jQuery.colorbox) {
+                parentWindow.jQuery.colorbox.close();
+            }
+            if (parentWindow.location) {
+                parentWindow.location.href = target;
+                return;
+            }
+        } catch (e) {}
+    }
+
+    if (window.top && window.top !== window) {
+        window.top.location.href = target;
+    } else {
+        window.location.href = target;
+    }
+})();
+</script>
+</body>
+</html>
+HTML
+    );
 }
 
 // QM+ TV edit


### PR DESCRIPTION
## Summary
- switch the QuickManager post-save redirect to use a 303 response to avoid the manager URL being cached
- update the quickmanagerclose handler to close the ColorBox iframe and refresh the parent window reliably

## Testing
- php -l assets/plugins/qm/inc/on_doc_form_save.php
- php -l assets/plugins/qm/inc/on_web_page_prerender.php

------
https://chatgpt.com/codex/tasks/task_e_68fdc53e3fd8832d8f57038c0d9b9edb