### PR TITLE
Define OldFunctions property on DocumentParser

### DIFF
--- a/manager/includes/document.parser.class.inc.php
+++ b/manager/includes/document.parser.class.inc.php
@@ -76,6 +76,8 @@ class DocumentParser
     public $uaType;
     public $functionLog = [];
     public $currentSnippetCall;
+    /** @var OldFunctions */
+    public $old;
     public $previewObject = ''; //プレビュー用のPOSTデータを保存
     public $snipLapCount;
     public $chunkieCache;


### PR DESCRIPTION
## Summary
- declare the `$old` property on `DocumentParser` to prevent dynamic property creation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fdd2cb1b70832dbd2a8e9ee6741682