### PR TITLE
Fix duplicate DocumentParser old property declaration

### DIFF
--- a/manager/includes/document.parser.class.inc.php
+++ b/manager/includes/document.parser.class.inc.php
@@ -99,7 +99,6 @@ class DocumentParser
     public $revision;
     public $revisionObject;
     public $filter;
-    protected $old;
 
     private $baseTime = ''; //タイムマシン(基本は現在時間)
 


### PR DESCRIPTION
## Summary
- remove the duplicate protected $old property from DocumentParser to avoid redeclaration

## Testing
- php -l manager/includes/document.parser.class.inc.php

------
https://chatgpt.com/codex/tasks/task_e_68fdf9b014a4832db221cb23b69bb72f