### PR TITLE
Fix TinyMCE initialization under PHP 8

### DIFF
--- a/assets/plugins/tinymce/functions.php
+++ b/assets/plugins/tinymce/functions.php
@@ -468,7 +468,7 @@ class TinyMCE
         foreach ($ph as $name => $value) {
             $name = '[+' . $name . '+]';
             if (is_bool($value)) {
-                $value = $value ? 'true' : 'false';
+                $value = json_encode($value);
             } elseif ($value === null) {
                 $value = '';
             } elseif (!is_scalar($value)) {


### PR DESCRIPTION
## Summary
- default TinyMCE skin settings to strings before parsing skin/variant
- normalize placeholder replacements so null and non-scalar values render as empty strings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fe09bef164832d834169741bff4480