### PR TITLE
Prevent module GUID null assignments when saving elements

### DIFF
--- a/manager/processors/plugin/save_plugin.processor.php
+++ b/manager/processors/plugin/save_plugin.processor.php
@@ -17,7 +17,7 @@ $locked = postv('locked') == 'on' ? '1' : '0';
 $plugincode = db()->escape(postv('post'));
 $properties = db()->escape(postv('properties'));
 $disabled = postv('disabled') == "on" ? '1' : '0';
-$moduleguid = db()->escape(postv('moduleguid'));
+$moduleguid = db()->escape(postv('moduleguid', ''));
 $sysevents = postv('sysevents');
 if (empty($sysevents)) {
     $sysevents[] = 90;

--- a/manager/processors/snippet/save_snippet.processor.php
+++ b/manager/processors/snippet/save_snippet.processor.php
@@ -24,7 +24,7 @@ if (strncmp($snippet, '<?', 2) == 0) {
     }
 }
 $properties = db()->escape(postv('properties'));
-$moduleguid = db()->escape(postv('moduleguid'));
+$moduleguid = db()->escape(postv('moduleguid', ''));
 $sysevents = postv('sysevents');
 
 //Kyle Jaebker - added category support


### PR DESCRIPTION
## Summary
- ensure plugin saves default to an empty module GUID when none is provided
- apply the same safeguard for snippet saves to avoid NOT NULL violations

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fe0ac22e60832daaa22fb42fe5352b