### PR TITLE
Use helper escaping for allowed parents field

### DIFF
--- a/manager/actions/permission/mutate_user/tpl/form/tab_settings.php
+++ b/manager/actions/permission/mutate_user/tpl/form/tab_settings.php
@@ -18,8 +18,12 @@
     <tr>
         <th><?= lang('user_allowed_parents') ?>:</th>
         <td>
+            <?php
+            $allowedParents = user('allowed_parents');
+            $allowedParents = $allowedParents === null ? '' : $allowedParents;
+            ?>
             <input type="text" name="allowed_parents" class="inputBox"
-                value="<?= htmlspecialchars(user('allowed_parents')) ?>" />
+                value="<?= hsc($allowedParents) ?>" />
             <div><?= lang('user_allowed_parents_message') ?></div>
         </td>
     </tr>


### PR DESCRIPTION
## Summary
- normalize the allowed parents value to an empty string when unset
- escape the allowed parents input via the shared hsc helper

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ff584f2f8c832d8efec74aabbf14c0