### PR TITLE
Handle null values when escaping user settings

### DIFF
--- a/manager/includes/document.parser.class.inc.php
+++ b/manager/includes/document.parser.class.inc.php
@@ -5640,7 +5640,11 @@ class DocumentParser
 
     public function hsc($str, $flags = ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401, $encode = null, $double_encode = true)
     {
-        if (!$str) {
+        if ($str === null) {
+            return '';
+        }
+
+        if (is_object($str)) {
             return $str;
         }
 
@@ -5648,16 +5652,25 @@ class DocumentParser
             foreach ($str as $k => $v) {
                 $str[$k] = $this->hsc($v, $flags, $encode, $double_encode);
             }
+
             return $str;
         }
 
-        if (!$encode) {
+        if ($encode === null) {
             $encode = $this->config('modx_charset', 'utf-8');
+        }
+
+        if (!is_string($str)) {
+            if (is_bool($str)) {
+                $str = $str ? '1' : '';
+            } else {
+                $str = (string) $str;
+            }
         }
 
         $ent_str = htmlspecialchars($str, $flags, $encode, $double_encode);
 
-        if ($str && $ent_str == '') {
+        if ($str !== '' && $ent_str === '') {
             $ent_str = $this->hsc(
                 mb_convert_encoding(
                     $str,

--- a/manager/includes/helpers.php
+++ b/manager/includes/helpers.php
@@ -94,21 +94,34 @@ if (!function_exists('str_ends_with')) {
 
 function hsc($string = '', $flags = ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401, $encode = null, $double_encode = true)
 {
-    if(!$string) {
-        return $string;
+    if ($string === null) {
+        return '';
     }
+
     if (is_object($string)) {
         return $string;
     }
-    if(is_array($string)) {
-        foreach($string as $i=>$v) {
+
+    if (is_array($string)) {
+        foreach ($string as $i => $v) {
             $string[$i] = hsc($v, $flags, $encode, $double_encode);
         }
+
         return $string;
     }
-    if($encode===null) {
+
+    if ($encode === null) {
         $encode = 'utf-8';
     }
+
+    if (!is_string($string)) {
+        if (is_bool($string)) {
+            $string = $string ? '1' : '';
+        } else {
+            $string = (string) $string;
+        }
+    }
+
     return htmlspecialchars($string, $flags, $encode, $double_encode);
 }
 


### PR DESCRIPTION
## Summary
- normalize values passed to the global hsc helper to safely handle null and non-string data
- align DocumentParser::hsc with the helper to prevent deprecated htmlspecialchars warnings during rendering

## Testing
- php -l manager/includes/helpers.php
- php -l manager/includes/document.parser.class.inc.php

------
https://chatgpt.com/codex/tasks/task_e_68ff759a9d78832d819e9735ed677194