### PR TITLE
Include settings version in basic config cache

### DIFF
--- a/manager/includes/cache_sync.class.php
+++ b/manager/includes/cache_sync.class.php
@@ -215,6 +215,12 @@ class synccache
             '$cache_type = %s;',
             config('cache_type', 1)
         );
+        if (isset($config['settings_version'])) {
+            $content[] = sprintf(
+                '$settings_version = "%s";',
+                $config['settings_version']
+            );
+        }
         if (isset($site_sessionname) && $site_sessionname) {
             $content[] = sprintf(
                 '$site_sessionname = "%s";',


### PR DESCRIPTION
## Summary
- add the settings version to the generated basicConfig cache file when available

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ff8773fb14832dbac89d05c08d10e1