### PR TITLE
Fix manager reload after completing upgrade settings

### DIFF
--- a/manager/actions/wait.static.php
+++ b/manager/actions/wait.static.php
@@ -12,7 +12,7 @@ if (anyv('r') == 10) {
         "document.location.href='index.php?a=3&id=%s';", anyv('id')
     );
 } else {
-    $ph['reload'] = 'document.location.href="index.php?a=2"';
+    $ph['reload'] = 'top.location.href="index.php?a=2"';
 }
 
 $tpl = get_tpl();


### PR DESCRIPTION
## Summary
- ensure the post-upgrade wait screen reloads the entire manager

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ff9204f258832db6ebe754c0b500a2