### PR TITLE
Handle null path when encoding file manager links

### DIFF
--- a/manager/actions/element/files.dynamic.php
+++ b/manager/actions/element/files.dynamic.php
@@ -46,7 +46,7 @@ if (!is_readable($startpath)) {
     <ul class="actionButtons">
         <?php
         if (getv('mode') !== 'drill') {
-            $href = 'a=31&path=' . urlencode(anyv('path', ''));
+            $href = 'a=31&path=' . urlencode($startpath);
         } else {
             $href = 'a=2';
         }


### PR DESCRIPTION
## Summary
- avoid passing null to `urlencode` when building the file manager path parameter

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69022ba398a8832d84ba9238a1608191