### PR TITLE
Handle missing role publishing entries

### DIFF
--- a/manager/index.php
+++ b/manager/index.php
@@ -97,7 +97,7 @@ switch (manager()->action) {
             $content = file_get_contents(MODX_CACHE_PATH . 'rolePublishing.idx.php');
             $role = unserialize($content, ['allowed_classes' => false]);
             $mgrRole = sessionv('mgrRole', 0);
-            if (is_array($role) && array_key_exists($mgrRole, $role)) {
+            if (isset($role[$mgrRole])) {
                 if (sessionv('mgrLastlogin', 0) < $role[$mgrRole]) {
                     @session_destroy();
                     session_unset();


### PR DESCRIPTION
## Summary
- avoid accessing undefined role publishing entries when validating manager sessions
- guard the manager logout flow by ensuring the role publishing index contains the current role before comparing timestamps

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69022efea96c832dbddaa6ae0617ebfe