### PR TITLE
Ensure base packages install without manual selection

### DIFF
--- a/install/functions.php
+++ b/install/functions.php
@@ -548,6 +548,40 @@ function withSample($installset)
     return true;
 }
 
+function shouldInstallElement($index, $installset, $selected, $installSampleData = false)
+{
+    $selected = is_array($selected) ? $selected : [];
+    $installset = is_array($installset) ? $installset : [];
+
+    if (in_array($index, $selected)) {
+        return true;
+    }
+    if ($installSampleData && in_array('sample', $installset)) {
+        return true;
+    }
+    if (in_array('base', $installset)) {
+        return true;
+    }
+
+    return false;
+}
+
+function hasInstallableElement($items, $selected, $installSampleData = false)
+{
+    if (!is_array($items) || !$items) {
+        return false;
+    }
+
+    foreach ($items as $index => $info) {
+        $installset = isset($info['installset']) ? $info['installset'] : [];
+        if (shouldInstallElement($index, $installset, $selected, $installSampleData)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 function convert2utf8mb4() {
     include MODX_SETUP_PATH . 'convert2utf8mb4.php';
     $convert = new convert2utf8mb4();

--- a/install/processors/prc_insChunks.inc.php
+++ b/install/processors/prc_insChunks.inc.php
@@ -1,15 +1,15 @@
 <?php
 global $errors, $tplChunks, $modx_version;
-if (!sessionv('chunk') && !sessionv('installdata')) {
+$selectedChunks = sessionv('chunk');
+$installSampleData = sessionv('installdata') == 1;
+if (!hasInstallableElement($tplChunks, $selectedChunks, $installSampleData)) {
     return;
 }
 
 echo sprintf('<h3>%s:</h3>', lang('chunks'));
 foreach ($tplChunks as $i => $tplInfo) {
-    if (!in_array($i, sessionv('chunk'))) {
-        if (!sessionv('installdata') || !in_array('sample', $tplInfo['installset'])) {
-            continue;
-        }
+    if (!shouldInstallElement($i, $tplInfo['installset'], $selectedChunks, $installSampleData)) {
+        continue;
     }
     if (!is_file($tplInfo['tpl_file_path'])) {
         echo ng(

--- a/install/processors/prc_insModules.inc.php
+++ b/install/processors/prc_insModules.inc.php
@@ -1,13 +1,15 @@
 <?php
 global $errors, $tplModules;
-if (!sessionv('module') && !sessionv('installdata')) {
+$selectedModules = sessionv('module');
+$installSampleData = sessionv('installdata') == 1;
+if (!hasInstallableElement($tplModules, $selectedModules, $installSampleData)) {
     return;
 }
 
 echo '<h3>' . lang('modules') . ':</h3>';
 
 foreach ($tplModules as $k => $tplInfo) {
-    if (!in_array($k, sessionv('module')) && !withSample($tplInfo['installset'])) {
+    if (!shouldInstallElement($k, $tplInfo['installset'], $selectedModules, $installSampleData)) {
         continue;
     }
 

--- a/install/processors/prc_insPlugins.inc.php
+++ b/install/processors/prc_insPlugins.inc.php
@@ -1,19 +1,15 @@
 <?php
 global $errors, $tplPlugins;
-if (!sessionv('plugin') && !sessionv('installdata')) {
+$selectedPlugins = sessionv('plugin');
+$installSampleData = sessionv('installdata') == 1;
+if (!hasInstallableElement($tplPlugins, $selectedPlugins, $installSampleData)) {
     return;
 }
 
 echo '<h3>' . lang('plugins') . ':</h3>';
 
 foreach ($tplPlugins as $i => $tplInfo) {
-    if (in_array('sample', $tplInfo['installset']) && sessionv('installdata') == 1) {
-        $installSample = true;
-    } else {
-        $installSample = false;
-    }
-
-    if (!in_array($i, sessionv('plugin')) && !$installSample) {
+    if (!shouldInstallElement($i, $tplInfo['installset'], $selectedPlugins, $installSampleData)) {
         continue;
     }
 

--- a/install/processors/prc_insSnippets.inc.php
+++ b/install/processors/prc_insSnippets.inc.php
@@ -1,13 +1,15 @@
 <?php
 global $errors, $tplSnippets;
-if (!sessionv('snippet') && !sessionv('installdata')) {
+$selectedSnippets = sessionv('snippet');
+$installSampleData = sessionv('installdata') == 1;
+if (!hasInstallableElement($tplSnippets, $selectedSnippets, $installSampleData)) {
     return;
 }
 
 echo '<h3>' . lang('snippets') . ':</h3>';
 
 foreach ($tplSnippets as $k => $tplInfo) {
-    if (!in_array($k, sessionv('snippet')) && !withSample($tplInfo['installset'])) {
+    if (!shouldInstallElement($k, $tplInfo['installset'], $selectedSnippets, $installSampleData)) {
         continue;
     }
 

--- a/install/processors/prc_insTVs.inc.php
+++ b/install/processors/prc_insTVs.inc.php
@@ -4,19 +4,15 @@ if (sessionv('is_upgradeable')) {
     return;
 }
 
-if (!sessionv('tv') && !sessionv('installdata')) {
+$selectedTVs = sessionv('tv');
+$installSampleData = sessionv('installdata') == 1;
+if (!hasInstallableElement($tplTVs, $selectedTVs, $installSampleData)) {
     return;
 }
 
 echo "<h3>" . lang('tvs') . ":</h3> ";
 foreach ($tplTVs as $i => $tplInfo) {
-    if (in_array('sample', $tplInfo['installset']) && sessionv('installdata') == 1) {
-        $installSample = true;
-    } else {
-        $installSample = false;
-    }
-
-    if (!in_array($i, sessionv('tv')) && !$installSample) {
+    if (!shouldInstallElement($i, $tplInfo['installset'], $selectedTVs, $installSampleData)) {
         continue;
     }
 

--- a/install/processors/prc_insTemplates.inc.php
+++ b/install/processors/prc_insTemplates.inc.php
@@ -3,20 +3,16 @@ global $errors, $tplTemplates;
 if (sessionv('is_upgradeable')) {
     return;
 }
-if (!sessionv('template') && !sessionv('installdata')) {
+$selectedTemplates = sessionv('template');
+$installSampleData = sessionv('installdata') == 1;
+if (!hasInstallableElement($tplTemplates, $selectedTemplates, $installSampleData)) {
     return;
 }
 
 echo "<h3>" . lang('templates') . ":</h3>";
 
 foreach ($tplTemplates as $i => $tplInfo) {
-    if (in_array('sample', $tplInfo['installset']) && sessionv('installdata') == 1) {
-        $installSample = true;
-    } else {
-        $installSample = false;
-    }
-
-    if (!in_array($i, sessionv('template')) && !$installSample) {
+    if (!shouldInstallElement($i, $tplInfo['installset'], $selectedTemplates, $installSampleData)) {
         continue;
     }
 


### PR DESCRIPTION
## Summary
- add helper utilities to determine when installers should run for base assets
- update template, TV, chunk, snippet, plugin, and module processors to always install base items

## Testing
- php -l install/functions.php
- php -l install/processors/prc_insTemplates.inc.php
- php -l install/processors/prc_insTVs.inc.php
- php -l install/processors/prc_insChunks.inc.php
- php -l install/processors/prc_insSnippets.inc.php
- php -l install/processors/prc_insPlugins.inc.php
- php -l install/processors/prc_insModules.inc.php

------
https://chatgpt.com/codex/tasks/task_e_69022e33e64c832d8cc85742d359f1cd