### PR TITLE
Handle missing oldusername during web user form restore

### DIFF
--- a/manager/actions/permission/mutate_web_user.dynamic.php
+++ b/manager/actions/permission/mutate_web_user.dynamic.php
@@ -91,7 +91,9 @@ if (manager()->hasFormValues()) {
     $userdata = array_merge($userdata, $form_v);
     $userdata['dob'] = ConvertDate($userdata['dob']);
     $usernamedata['username'] = $userdata['newusername'];
-    $usernamedata['oldusername'] = $form_v['oldusername'];
+    if (isset($form_v['oldusername'])) {
+        $usernamedata['oldusername'] = $form_v['oldusername'];
+    }
     $usersettings = array_merge($usersettings, $form_v);
     $usersettings['allowed_days'] = is_array($form_v['allowed_days']) ? implode(",", $form_v['allowed_days']) : "";
     extract($usersettings, EXTR_OVERWRITE);


### PR DESCRIPTION
## Summary
- guard the web user form restore logic against a missing `oldusername` value to prevent warnings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69023677a020832d9da7a3b0e6f9585b