### PR TITLE
Fix module list filtering when no search query

### DIFF
--- a/manager/actions/element/modules.static.php
+++ b/manager/actions/element/modules.static.php
@@ -22,10 +22,7 @@ $sqlQuery = '';
 if (anyv('op') === 'reset') {
     $_PAGE['vs']['search'] = '';
 } else {
-    $query = anyv('search');
-    if ($query === null || $query === '') {
-        $query = array_get($_PAGE, 'vs.search', '');
-    }
+    $query = anyv('search', array_get($_PAGE, 'vs.search', ''));
     if ($query !== '') {
         $sqlQuery = db()->escape($query);
     }


### PR DESCRIPTION
## Summary
- ensure the module manager only escapes the search query when it contains a value
- prevent the generated SQL filter from matching the literal string NULL

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6902392fe048832da328c1beadf925ca