### PR TITLE
Remove legacy serialization fallback from frontend cache

### DIFF
--- a/index.php
+++ b/index.php
@@ -46,10 +46,12 @@ if (isset($conditional_get) && $conditional_get == 1) {
             $output = fread($handle, filesize($target));
             unset($handle);
             [$head, $output] = explode('<!--__MODxCacheSpliter__-->', $output, 2);
-            if (strpos($head, '"text/html";') === false) {
-                $type = unserialize($head);
+            $type = json_decode($head, true);
+            if (json_last_error() === JSON_ERROR_NONE && is_string($type) && $type !== '') {
                 header('Content-Type:' . $type . '; charset=utf-8');
-            } else header('Content-Type:text/html; charset=utf-8');
+            } else {
+                header('Content-Type:text/html; charset=utf-8');
+            }
             $msize = memory_get_peak_usage() - $mstart;
             $units = ['B', 'KB', 'MB'];
             $pos = 0;


### PR DESCRIPTION
## Summary
- serve cached pages using JSON-encoded headers only and default to text/html when decoding fails
- stop writing serialized page metadata or content types to the cache, aborting cache saves if JSON encoding fails

## Testing
- php -l index.php
- php -l manager/includes/document.parser.class.inc.php

------
https://chatgpt.com/codex/tasks/task_e_69023e95d494832dadf19117bb8a69f5