### PR TITLE
Fix default event log search filter

### DIFF
--- a/manager/actions/report/eventlog.dynamic.php
+++ b/manager/actions/report/eventlog.dynamic.php
@@ -15,7 +15,7 @@ if (anyv('op') === 'reset') {
     $search = $query = '';
     $_PAGE['vs']['search'] = '';
 } else {
-    $search = $query = anyv('search', array_get($_PAGE, 'vs.search'));
+    $search = $query = anyv('search', array_get($_PAGE, 'vs.search', ''));
     if (!is_numeric($search)) {
         $search = db()->escape($query);
     }


### PR DESCRIPTION
## Summary
- ensure the event log search state defaults to an empty string when no query is provided
- prevent the initial event log view from filtering results by the literal string NULL

## Testing
- php -l manager/actions/report/eventlog.dynamic.php

------
https://chatgpt.com/codex/tasks/task_e_69024259175c832d822ee1f43f80cecd