### PR TITLE
Default installer connection fields from environment

### DIFF
--- a/install/actions/connection.php
+++ b/install/actions/connection.php
@@ -9,18 +9,32 @@ if (sessionv('prevAction') === 'options') {
     sessionv('*plugin', postv('plugin', []));
     sessionv('*module', postv('module', []));
 }
+$getEnv = static function (string $key, $default = null) {
+    if (function_exists('env')) {
+        $value = env($key, $default);
+    } else {
+        $value = getenv($key);
+        if ($value === false) {
+            $value = $default;
+        }
+    }
+
+    return ($value === null || $value === false || $value === '') ? $default : $value;
+};
+
 $ph = array_merge(
-    $ph, [
+    $ph,
+    [
         'adminname'         => 'admin',
-        'database_server'   => sessionv('database_server', 'localhost'),
-        'table_prefix'      => sessionv('table_prefix', 'modx_'),
+        'database_server'   => sessionv('database_server', $getEnv('DB_HOST', 'localhost')),
+        'table_prefix'      => sessionv('table_prefix', $getEnv('TABLE_PREFIX', 'modx_')),
         'is_upgradeable'    => sessionv('is_upgradeable'),
         'adminemail'        => sessionv('adminemail', ''),
         'adminpass'         => sessionv('adminpass', ''),
         'adminpassconfirm'  => sessionv('adminpassconfirm', ''),
-        'database_user'     => sessionv('database_user', ''),
-        'database_password' => sessionv('database_password', ''),
-        'dbase'             => sessionv('dbase', ''),
+        'database_user'     => sessionv('database_user', $getEnv('DB_USERNAME', '')),
+        'database_password' => sessionv('database_password', $getEnv('DB_PASSWORD', '')),
+        'dbase'             => sessionv('dbase', $getEnv('DB_DATABASE', '')),
     ]
 );
 if ($ph['database_server'] === '127.0.0.1') {


### PR DESCRIPTION
## Summary
- load database connection defaults in the installer from .env when session data is empty
- keep existing fallbacks so the form still defaults to localhost/modx_ when no environment values exist

## Testing
- php -l install/actions/connection.php

------
https://chatgpt.com/codex/tasks/task_e_690710f80b48832da33e084dd40f5a09