### PR TITLE
Fix creation of placeholder resource browser directories

### DIFF
--- a/manager/processors/save_settings.processor.php
+++ b/manager/processors/save_settings.processor.php
@@ -32,14 +32,16 @@ header("Location: index.php?a=7&r=10");
 
 function setPermission()
 {
-    if (!is_dir(formv('rb_base_dir') . 'images')) {
-        mkd(formv('rb_base_dir') . 'images');
+    $rb_base_dir = str_replace('[(base_path)]', MODX_BASE_PATH, formv('rb_base_dir'));
+
+    if (!is_dir($rb_base_dir . 'images')) {
+        mkd($rb_base_dir . 'images');
     }
-    if (!is_dir(formv('rb_base_dir') . 'files')) {
-        mkd(formv('rb_base_dir') . 'files');
+    if (!is_dir($rb_base_dir . 'files')) {
+        mkd($rb_base_dir . 'files');
     }
-    if (!is_dir(formv('rb_base_dir') . 'media')) {
-        mkd(formv('rb_base_dir') . 'media');
+    if (!is_dir($rb_base_dir . 'media')) {
+        mkd($rb_base_dir . 'media');
     }
     if (!is_dir(MODX_BASE_PATH . 'temp/export')) {
         mkd(MODX_BASE_PATH . 'temp/export');


### PR DESCRIPTION
## Summary
- ensure the resource browser directory setup resolves the base path placeholder before creating folders

## Testing
- php -l manager/processors/save_settings.processor.php

------
https://chatgpt.com/codex/tasks/task_e_6907244fac74832d9c56dfe9d6f3db5c