### PR TITLE
Skip license agreement step during upgrades

### DIFF
--- a/install/actions/summary.php
+++ b/install/actions/summary.php
@@ -1,6 +1,11 @@
 <?php
 
 $chkagree = postv('chkagree', sessionv('chkagree'));
+$isUpgrade = sessionv('is_upgradeable');
+if ($isUpgrade) {
+    $chkagree = 1;
+    $_SESSION['chkagree'] = 1;
+}
 
 if (sessionv('prevAction') === 'options') {
     $_SESSION['installdata'] = postv('installdata', '');
@@ -229,6 +234,7 @@ $agreeToggle = $errors > 0 ? '' : " onclick=\"if(document.getElementById('chkagr
         <input type="hidden" name="prev_action" value="summary" />
     </div>
 
+    <?php if (!$isUpgrade): ?>
         <h2><?= lang('agree_to_terms') ?></h2>
         <p>
             <input type="checkbox" value="1" id="chkagree" name="chkagree"
@@ -236,6 +242,7 @@ $agreeToggle = $errors > 0 ? '' : " onclick=\"if(document.getElementById('chkagr
                 for="chkagree"
                 style="display:inline;float:none;line-height:18px;"> <?= lang('iagree_box') ?> </label>
         </p>
+    <?php endif; ?>
         <p class="buttonlinks">
             <a href="javascript:void(0);" class="prev"
                title="<?= lang('btnback_value') ?>"><span><?= lang('btnback_value') ?></span></a>


### PR DESCRIPTION
## Summary
- automatically mark the license agreement as accepted when an upgrade is detected
- hide the license confirmation checkbox during upgrades so the flow can continue without extra input

## Testing
- php -l install/actions/summary.php

------
https://chatgpt.com/codex/tasks/task_e_690729a82ce0832db51d05e1c75f93c7