### PR TITLE
Fix installer footer layout

### DIFF
--- a/install/style.css
+++ b/install/style.css
@@ -25,6 +25,9 @@ body {
     font-variant: normal;
     font-weight: normal;
     line-height: 1.5;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
 }
 
 label {
@@ -363,6 +366,7 @@ span.mono {
 
 #contentarea {
     min-height: 250px;
+    flex: 1 0 auto;
 }
 
 #contentarea h2 {


### PR DESCRIPTION
## Summary
- ensure the installer layout stretches to fill the viewport
- allow the footer to stay pinned to the bottom of short pages

## Testing
- Manual verification

------
https://chatgpt.com/codex/tasks/task_e_690735652290832d82a72b2c56e3bdb7