### PR TITLE
Harden timestamp utilities against null input

### DIFF
--- a/manager/actions/element/mutate_templates.dynamic.php
+++ b/manager/actions/element/mutate_templates.dynamic.php
@@ -411,8 +411,22 @@ function template($key, $default = null)
 
 function id()
 {
-    if (preg_match('@^[0-9]+$@', getv('id'))) {
-        return getv('id');
+    $id = getv('id');
+    if ($id === null) {
+        return '';
+    }
+
+    if (!is_scalar($id)) {
+        return '';
+    }
+
+    $id = trim((string)$id);
+    if ($id === '') {
+        return '';
+    }
+
+    if (preg_match('@^[0-9]+$@', $id)) {
+        return $id;
     }
     return '';
 }


### PR DESCRIPTION
## Summary
- guard `DocumentParser::toDateFormat` against null and non-scalar values before formatting
- make `DocumentParser::toTimeStamp` safely normalise inputs and handle parse failures
- normalise the template mutation `id()` helper to ignore non-numeric request values

## Testing
- php -l manager/includes/document.parser.class.inc.php
- php -l manager/actions/element/mutate_templates.dynamic.php

------
https://chatgpt.com/codex/tasks/task_e_690756aa5e94832d826adfc5d285cbe1