### PR TITLE
Fix export property warning and site cache cleanup

### DIFF
--- a/manager/includes/cache_sync.class.php
+++ b/manager/includes/cache_sync.class.php
@@ -120,7 +120,7 @@ class synccache
         if ($target === 'pageCache') {
             $pattern = '@\.pageCache\.php$@';
         } else {
-            $pattern = '@\.*$@';
+            $pattern = null;
         }
 
         $files = $this->getFileList($this->cachePath, $pattern);
@@ -140,7 +140,9 @@ class synccache
             }
             $rs = null;
             if (is_file($file_path)) {
-                $rs = unlink($file_path);
+                if ($pattern === null || preg_match($pattern, $file_path)) {
+                    $rs = unlink($file_path);
+                }
             } elseif (is_dir($file_path)) {
                 $rs = rmdir($file_path);
             }
@@ -575,7 +577,7 @@ class synccache
 
         $list = [];
         foreach ($files as $obj) {
-            if (is_file($obj) && preg_match($pattern, $obj)) {
+            if (is_file($obj) && ($pattern === null || preg_match($pattern, $obj))) {
                 $list[] = $obj;
             } elseif (is_dir($obj)) {
                 $list[] = $obj;

--- a/manager/includes/document.parser.class.inc.php
+++ b/manager/includes/document.parser.class.inc.php
@@ -44,6 +44,7 @@ class DocumentParser
     public $queryTime;
     public $currentSnippet;
     public $currentSnippetCode;
+    public $export;
     public $aliases;
     public $entrypage;
     public $dumpSQL;


### PR DESCRIPTION
## Summary
- avoid creating a dynamic DocumentParser::$export property by declaring it explicitly
- allow site cache cleanup to remove all files before deleting directories to prevent warnings

## Testing
- php -l manager/includes/cache_sync.class.php
- php -l manager/includes/document.parser.class.inc.php

------
https://chatgpt.com/codex/tasks/task_e_69077dfa0850832d8aad9bb7760d4ed7