### PR TITLE
Ensure context parsing defaults to empty strings

### DIFF
--- a/manager/includes/document.parser.class.inc.php
+++ b/manager/includes/document.parser.class.inc.php
@@ -2135,8 +2135,8 @@ class DocumentParser
         }
         [$key, $str] = explode('@', $key, 2);
 
-        list($context, $option) = array_pad(explode('(', $str, 2), 2, null);
-        if ($option) {
+        [$context, $option] = array_pad(explode('(', $str, 2), 2, '');
+        if ($option !== '') {
             $option = trim($option, ')(\'"`');
         }
 


### PR DESCRIPTION
## Summary
- default missing context filters to empty strings before trimming
- avoid passing null into string functions when parsing context expressions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6908248af1b4832da38613f0b298a5bc