### PR TITLE
fix: remove deprecated IIS support and fix is_iis() logic bug

### DIFF
--- a/install/actions/install.php
+++ b/install/actions/install.php
@@ -9,7 +9,7 @@ session_destroy();
 
 if ($errors == 0) {
     // check if install folder is removeable
-    if ((is_writable('../install') || is_webmatrix()) && !is_iis()) { ?>
+    if (is_writable('../install') || is_webmatrix()) { ?>
         <label style="float:left;line-height:18px;">
             <input
                 type="checkbox" id="rminstaller" value="1" checked

--- a/install/functions.php
+++ b/install/functions.php
@@ -340,11 +340,6 @@ function is_webmatrix()
     return isset($_SERVER['WEBMATRIXMODE']) ? true : false;
 }
 
-function is_iis()
-{
-    return strpos($_SERVER['SERVER_SOFTWARE'], 'IIS') ? true : false;
-}
-
 function isUpGradeable()
 {
     error_reporting(E_ALL & ~E_NOTICE);


### PR DESCRIPTION
- Remove is_iis() function that had a strpos() bug (returns 0/falsy when 'IIS' is at position 0)
- Remove IIS-specific condition from installer auto-delete check
- IIS is considered deprecated for modern PHP 8 environments

Fixes issue in install/functions.php where is_iis() would incorrectly return false when 'IIS' appears at the start of SERVER_SOFTWARE string.

@codex 日本語でレビュー