### PR TITLE
Replace deprecated join() function with implode()

### DIFF
--- a/assets/plugins/managermanager/utilities.inc.php
+++ b/assets/plugins/managermanager/utilities.inc.php
@@ -94,7 +94,7 @@ function tplUseTvs($tpl_id, $tvs = '', $types = '')
         $where[] = sprintf('type IN %s', makeSqlList($types));
     }
     if ($where) {
-        $where = join(' AND ', $where);
+        $where = implode(' AND ', $where);
     }
 
     // Do the SQL query

--- a/assets/plugins/tinymce/js/get_template.php
+++ b/assets/plugins/tinymce/js/get_template.php
@@ -76,7 +76,7 @@ if ($docid = getv('docid')) {
             foreach ($chunks as $i => $v) {
                 $chunks[$i] = db()->escape(trim($v));
             }
-            $chunks = join("','", $chunks);
+            $chunks = implode("','", $chunks);
             $where = "`name` IN ('{$chunks}')";
             $orderby = "FIELD(name, '{$chunks}')";
         } else {
@@ -94,7 +94,7 @@ if ($docid = getv('docid')) {
         }
     }
 
-    if (0 < count($list)) $output = 'var tinyMCETemplateList = [' . join(',', $list) . '];';
+    if (0 < count($list)) $output = 'var tinyMCETemplateList = [' . implode(',', $list) . '];';
 }
 
 if ($output) {

--- a/assets/snippets/ditto/classes/ditto.class.inc.php
+++ b/assets/snippets/ditto/classes/ditto.class.inc.php
@@ -958,7 +958,7 @@ class ditto
             foreach ($_ as $i => $v) {
                 $_[$i] = trim($v);
             }
-            $where = 'AND sc.' . join(' AND sc.', $_);
+            $where = 'AND sc.' . implode(' AND sc.', $_);
         }
 
         $sort = $randomize ? 'RAND()' : $orderBy['sql'];
@@ -1064,17 +1064,17 @@ class ditto
         $where = [];
         $docGroup = evo()->getUserDocGroups();
         if ($docGroup) {
-            $where[] = sprintf('sc.id IN (%s)', join(',', $ids));
+            $where[] = sprintf('sc.id IN (%s)', implode(',', $ids));
             $where[] = 'AND sc.deleted=0';
             if (evo()->isFrontend()) {
                 $where[] = sprintf(
                     'AND (sc.privateweb=0 OR dg.document_group IN (%s))'
-                    , join(',', $docGroup)
+                    , implode(',', $docGroup)
                 );
             } elseif ($_SESSION['mgrRole'] != 1) {
                 $where[] = sprintf(
                     'AND (sc.privatemgr=0 OR dg.document_group IN (%s))'
-                    , join(',', $docGroup)
+                    , implode(',', $docGroup)
                 );
             }
             if ($published) {
@@ -1087,7 +1087,7 @@ class ditto
                 , $where
             );
         } else {
-            $where[] = sprintf('id IN (%s)', join(',', $ids));
+            $where[] = sprintf('id IN (%s)', implode(',', $ids));
             $where[] = 'AND deleted=0';
             if (evo()->isFrontend()) {
                 $where[] = 'AND privateweb=0';

--- a/assets/snippets/eform/eform.inc.php
+++ b/assets/snippets/eform/eform.inc.php
@@ -461,7 +461,7 @@ function eForm($modx, $params)
                     $fields[$name] = $value;
                 }
                 if (is_array($value)) {
-                    $fields[$name] = join(', ', $value);
+                    $fields[$name] = implode(', ', $value);
                 }
             }
             # set postdate

--- a/assets/snippets/wayfinder/wayfinder.inc.php
+++ b/assets/snippets/wayfinder/wayfinder.inc.php
@@ -380,7 +380,7 @@ class Wayfinder
         }
 
         if ($classNames) {
-            return join(' ', $classNames);
+            return implode(' ', $classNames);
         }
         return '';
     }
@@ -550,7 +550,7 @@ class Wayfinder
         }
 
         $result = db()->select(
-            'DISTINCT ' . join(',', $fields)
+            'DISTINCT ' . implode(',', $fields)
             , $from
             , $where
             , $sort

--- a/install/actions/options.php
+++ b/install/actions/options.php
@@ -193,7 +193,7 @@ function block_templates($tplTemplates, $ph)
             $v['description']
         );
     }
-    return evo()->parseText(join("<br />\n", $_), $ph);
+    return evo()->parseText(implode("<br />\n", $_), $ph);
 }
 
 function block_tvs($tplTVs, $ph)
@@ -213,7 +213,7 @@ function block_tvs($tplTVs, $ph)
             $v['description']
         );
     }
-    return evo()->parseText(join("<br />\n", $_), $ph);
+    return evo()->parseText(implode("<br />\n", $_), $ph);
 }
 
 function block_chunks($tplChunks, $ph)
@@ -233,7 +233,7 @@ function block_chunks($tplChunks, $ph)
             $v['description']
         );
     }
-    return evo()->parseText(join("<br />\n", $_), $ph);
+    return evo()->parseText(implode("<br />\n", $_), $ph);
 }
 
 function block_modules($tplModules, $ph)
@@ -253,7 +253,7 @@ function block_modules($tplModules, $ph)
             $v['description']
         );
     }
-    return evo()->parseText(join("<br />\n", $_), $ph);
+    return evo()->parseText(implode("<br />\n", $_), $ph);
 }
 
 function block_plugins($tplPlugins, $ph)

--- a/manager/actions/document/mutate_content/action_buttons.php
+++ b/manager/actions/document/mutate_content/action_buttons.php
@@ -107,7 +107,7 @@ function ab_save()
     }
     $option[] = sprintf('<option id="stay3" value="close" %s >%s</option>', $selected['close'], lang('close'));
 
-    $ph['select'] = sprintf($ph['select'], join("\n", $option));
+    $ph['select'] = sprintf($ph['select'], implode("\n", $option));
 
     return parseText($tpl, $ph);
 }

--- a/manager/actions/document/mutate_content/fields.php
+++ b/manager/actions/document/mutate_content/fields.php
@@ -706,7 +706,7 @@ function fieldContentType()
     $body = parseText(
         file_get_tpl('field_content_type.tpl'),
         [
-            'option' => join("\n", $option)
+            'option' => implode("\n", $option)
         ]
     )
         . tooltip(lang('page_data_contentType_help'));

--- a/manager/actions/document/mutate_content/functions.php
+++ b/manager/actions/document/mutate_content/functions.php
@@ -435,10 +435,10 @@ function renderTr($head, $body, $rowstyle = '')
             }
             $i++;
         }
-        $ph['extra_head'] = join("\n", $extra_head);
+        $ph['extra_head'] = implode("\n", $extra_head);
     }
     if (is_array($body)) {
-        $body = join("\n", $body);
+        $body = implode("\n", $body);
     }
     $ph['body'] = $body;
     $ph['rowstyle'] = $rowstyle;

--- a/manager/actions/element/files.dynamic.php
+++ b/manager/actions/element/files.dynamic.php
@@ -212,7 +212,7 @@ if (!is_readable($startpath)) {
                 }
                 $count--;
             }
-            $topic_path = join(' / ', $pieces);
+            $topic_path = implode(' / ', $pieces);
         }
 
         ?> <b><?= mb_convert_encoding(

--- a/manager/actions/element/mutate_module_resources.dynamic.php
+++ b/manager/actions/element/mutate_module_resources.dynamic.php
@@ -67,8 +67,8 @@ switch (anyv('op')) {
                 $opid = intval($opid);
                 $v[] = "('{$id}','{$opid}','{$type}')";
             }
-            $values = join(',', $v);
-            $del_opids = join(',', $opids);
+            $values = implode(',', $v);
+            $del_opids = implode(',', $opids);
             db()->delete($tbl_site_module_depobj, "module='{$id}' AND resource IN ({$del_opids}) AND type='{$type}'");
             $ds = db()->query("INSERT INTO {$tbl_site_module_depobj} (module, resource, type) VALUES {$values}");
             if (!$ds) {

--- a/manager/actions/element/mutate_plugin.dynamic.php
+++ b/manager/actions/element/mutate_plugin.dynamic.php
@@ -652,7 +652,7 @@ function entity($key, $default = null)
 
                     function echoEventRows(&$evtnames)
                     {
-                        echo "<tr><td>" . join("</td><td>", $evtnames) . "</td></tr>";
+                        echo "<tr><td>" . implode("</td><td>", $evtnames) . "</td></tr>";
                         $evtnames = [];
                     }
 

--- a/manager/actions/element/mutate_tmplvars.dynamic.php
+++ b/manager/actions/element/mutate_tmplvars.dynamic.php
@@ -412,7 +412,7 @@ function entity($key, $default = null)
                                     }
                                     $row[$k] = '<option value="' . $k . '" ' . $selected . '>' . $v . '</option>';
                                 }
-                                echo join("\n", $row);
+                                echo implode("\n", $row);
                                 ?>
                             </select>
                         </td>

--- a/manager/actions/main/welcome.static.php
+++ b/manager/actions/main/welcome.static.php
@@ -187,7 +187,7 @@ if (evo()->hasPermission('exec_module')) {
 }
 $modules = '';
 if (0 < count($modulemenu)) {
-    $modules = join("\n", $modulemenu);
+    $modules = implode("\n", $modulemenu);
 }
 $modx->setPlaceholder('Modules', $modules);
 

--- a/manager/actions/permission/user_management.static.php
+++ b/manager/actions/permission/user_management.static.php
@@ -185,7 +185,7 @@ echo $cm->render();
                 $_lang['user_logincount'],
                 $_lang['user_block']
             ];
-            $grd->columns = join(',', $columns);
+            $grd->columns = implode(',', $columns);
             $colTypes = [
                 sprintf(
                     'template:<a class="gridRowIcon" href="#" onclick="return showContentMenu([+id+],event);" title="%s"><img src="' . $_style['icons_user'] . '" /></a><span class="[+class+]"><a href="index.php?a=12&id=[+id+]" title="%s">[+value+]</a></span>',
@@ -199,7 +199,7 @@ echo $cm->render();
                 '[+logincount+]',
                 '[+blocked+]'
             ];
-            $grd->colTypes = join('||', $colTypes);
+            $grd->colTypes = implode('||', $colTypes);
             if ($listmode == '1') {
                 $grd->pageSize = 0;
             }

--- a/manager/actions/report/sysinfo.static.php
+++ b/manager/actions/report/sysinfo.static.php
@@ -139,7 +139,7 @@ global $database_connection_method, $lastInstallTime;
                 $mb_get_info['http_input'] = ini_get('mbstring.http_input');
                 foreach ($mb_get_info as $key => $value) {
                     if (is_array($value)) {
-                        $value = join(',', $value);
+                        $value = implode(',', $value);
                     }
                     echo '<tr><td style="padding-right:30px;">' . $key . '</td><td>' . $value . '</td></tr>' . "\n";
                 }

--- a/manager/actions/tool/bkmanager.static.php
+++ b/manager/actions/tool/bkmanager.static.php
@@ -312,14 +312,14 @@ if (sessionv('result_msg')) {
                         foreach ($last_result['0'] as $k => $v) {
                             $title[] = $k;
                         }
-                        $result = '<tr><th>' . join('</th><th>', $title) . '</th></tr>';
+                        $result = '<tr><th>' . implode('</th><th>', $title) . '</th></tr>';
                         foreach ($last_result as $row) {
                             $result_value = [];
                             if ($row) {
                                 foreach ($row as $k => $v) {
                                     $result_value[] = $v;
                                 }
-                                $result .= '<tr><td>' . join('</td><td>', $result_value) . '</td></tr>';
+                                $result .= '<tr><td>' . implode('</td><td>', $result_value) . '</td></tr>';
                             }
                         }
                         $style = '<style type="text/css">table th {border:1px solid #ccc;background-color:#ddd;}</style>';

--- a/manager/actions/tool/mutate_settings/tab4_manager_settings.inc.php
+++ b/manager/actions/tool/mutate_settings/tab4_manager_settings.inc.php
@@ -150,7 +150,7 @@
                             '<option value="[+value+]" [+selected+]>[*[+value+]*]</option>' . "\n"
                         );
                     }
-                    echo join("\n", $output)
+                    echo implode("\n", $output)
                     ?>
                 </select><br/>
                 <?= $_lang["setting_resource_tree_sortby_default_desc"] ?>
@@ -170,7 +170,7 @@
                         $r = [$v, $selected];
                         $output[] = str_replace($s, $r, $tpl);
                     }
-                    echo join("\n", $output)
+                    echo implode("\n", $output)
                     ?>
                 </select><br/>
                 <?= $_lang["setting_resource_tree_node_name_desc"] ?>

--- a/manager/frames/menu.php
+++ b/manager/frames/menu.php
@@ -373,31 +373,31 @@ $mxla = $modx_lang_attribute ? $modx_lang_attribute : 'en';
                     $tplActive = str_replace(']"><a', ']" class="active"><a', $tpl);
                     if (!empty($sitemenu)) {
                         echo $modx->parseText($tplActive,
-                            ['id' => '1', 'name' => $_lang['site'], 'menuitem' => join("\n", $sitemenu)]);
+                            ['id' => '1', 'name' => $_lang['site'], 'menuitem' => implode("\n", $sitemenu)]);
                     }
                     if (!empty($elementmenu)) {
                         echo $modx->parseText($tpl,
-                            ['id' => '2', 'name' => $_lang['elements'], 'menuitem' => join("\n", $elementmenu)]);
+                            ['id' => '2', 'name' => $_lang['elements'], 'menuitem' => implode("\n", $elementmenu)]);
                     }
                     if (!empty($modulemenu)) {
                         echo $modx->parseText($tpl,
-                            ['id' => '3', 'name' => $_lang['modules'], 'menuitem' => join("\n", $modulemenu)]);
+                            ['id' => '3', 'name' => $_lang['modules'], 'menuitem' => implode("\n", $modulemenu)]);
                     }
                     if (!empty($securitymenu)) {
                         echo $modx->parseText($tpl,
-                            ['id' => '4', 'name' => $_lang['users'], 'menuitem' => join("\n", $securitymenu)]);
+                            ['id' => '4', 'name' => $_lang['users'], 'menuitem' => implode("\n", $securitymenu)]);
                     }
                     if (!empty($usermenu)) {
                         echo $modx->parseText($tpl,
-                            ['id' => '7', 'name' => $_lang['user'], 'menuitem' => join("\n", $usermenu)]);
+                            ['id' => '7', 'name' => $_lang['user'], 'menuitem' => implode("\n", $usermenu)]);
                     }
                     if (!empty($toolsmenu)) {
                         echo $modx->parseText($tpl,
-                            ['id' => '5', 'name' => $_lang['tools'], 'menuitem' => join("\n", $toolsmenu)]);
+                            ['id' => '5', 'name' => $_lang['tools'], 'menuitem' => implode("\n", $toolsmenu)]);
                     }
                     if (!empty($reportsmenu)) {
                         echo $modx->parseText($tpl,
-                            ['id' => '6', 'name' => $_lang['reports'], 'menuitem' => join("\n", $reportsmenu)]);
+                            ['id' => '6', 'name' => $_lang['reports'], 'menuitem' => implode("\n", $reportsmenu)]);
                     }
                     ?>
                 </ul>

--- a/manager/frames/nodes.php
+++ b/manager/frames/nodes.php
@@ -297,7 +297,7 @@ function getNodes($indent, $parent = 0, $expandAll=null, $output = '')
             }
         }
         if (!empty($a)) {
-            $output .= '<script type="text/javascript">' . "\n" . join("\n", $a) . "\n</script>";
+            $output .= '<script type="text/javascript">' . "\n" . implode("\n", $a) . "\n</script>";
         }
     endwhile;
     return $output;
@@ -566,7 +566,7 @@ function getAlt($id, $alias, $menuindex, $hidemenu, $privatemgr, $privateweb)
     $_[] = "{$_lang['resource_opt_show_menu']}: " . ($hidemenu == 1 ? $_lang['no'] : $_lang['yes']);
     $_[] = "{$_lang['page_data_web_access']}: " . ($privateweb ? $_lang['private'] : $_lang['public']);
     $_[] = "{$_lang['page_data_mgr_access']}: " . ($privatemgr ? $_lang['private'] : $_lang['public']);
-    $alt = join("\n", $_);
+    $alt = implode("\n", $_);
     $alt = addslashes($alt);
     return htmlspecialchars($alt, ENT_QUOTES, $modx->config('modx_charset'));
 }

--- a/manager/includes/cache_sync.class.php
+++ b/manager/includes/cache_sync.class.php
@@ -292,7 +292,7 @@ class synccache
             );
         }
 
-        if (!evo()->saveToFile($this->cachePath . 'basicConfig.php', join("\n", $content))) {
+        if (!evo()->saveToFile($this->cachePath . 'basicConfig.php', implode("\n", $content))) {
             exit(sprintf('Cannot open file (%sbasicConfig.php)', $this->cachePath));
         }
     }

--- a/manager/includes/document.parser.class.inc.php
+++ b/manager/includes/document.parser.class.inc.php
@@ -849,7 +849,7 @@ class DocumentParser
 
             // Attach Document Groups and Scripts
             if (is_array($docGroups)) {
-                $this->documentObject['__MODxDocGroups__'] = join(',', $docGroups);
+                $this->documentObject['__MODxDocGroups__'] = implode(',', $docGroups);
             }
 
             switch ($this->config('cache_type')) {
@@ -1601,7 +1601,7 @@ class DocumentParser
             $rs = db()->update(
                 'published=0, publishedon=0',
                 '[+prefix+]site_content',
-                sprintf('id in (%s)', join(',', $unpub_ids))
+                sprintf('id in (%s)', implode(',', $unpub_ids))
             );
         }
 
@@ -2301,7 +2301,7 @@ class DocumentParser
         }
 
         if ($this->debug) {
-            $_ = join(', ', $matches[0]);
+            $_ = implode(', ', $matches[0]);
             $this->addLogEntry('$modx->' . __FUNCTION__ . "[{$_}]", $fstart);
         }
         return $content;
@@ -2361,7 +2361,7 @@ class DocumentParser
         }
 
         if ($this->debug) {
-            $_ = join(', ', $matches[0]);
+            $_ = implode(', ', $matches[0]);
             $this->addLogEntry('$modx->' . __FUNCTION__ . "[{$_}]", $fstart);
         }
         return $content;
@@ -2413,7 +2413,7 @@ class DocumentParser
             $content = str_replace($matches[0][$i], $value, $content);
         }
         if ($this->debug) {
-            $_ = join(', ', $matches[0]);
+            $_ = implode(', ', $matches[0]);
             $this->addLogEntry('$modx->' . __FUNCTION__ . "[{$_}]", $fstart);
         }
         return $content;
@@ -2637,7 +2637,7 @@ class DocumentParser
             }
             $cmd[] = $v;
         }
-        $cmd = join('', $cmd);
+        $cmd = implode('', $cmd);
         $cmd = (int)eval("return {$cmd};");
 
         return $cmd;
@@ -3477,7 +3477,7 @@ class DocumentParser
         if ($this->session('mgrRole')) {
             $_[] = sprintf('1=%d', (int)$this->session('mgrRole'));
         }
-        $access = join(' OR ', $_);
+        $access = implode(' OR ', $_);
 
         $result = db()->select(
             'sc.*',
@@ -3864,7 +3864,7 @@ class DocumentParser
                 $limit
             );
         } else {
-            $where[] = sprintf('id IN (%s)', join(',', $ids));
+            $where[] = sprintf('id IN (%s)', implode(',', $ids));
             if ($published !== null) {
                 $where[] = sprintf('AND published=%d', $published);
             }
@@ -4111,7 +4111,7 @@ class DocumentParser
                         foreach ($_ as $i => $v) {
                             $_[$i] = urlencode($v);
                         }
-                        $alPath = join('/', $_);
+                        $alPath = implode('/', $_);
                     } else {
                         $alPath = '';
                     }
@@ -4363,7 +4363,7 @@ class DocumentParser
         } // ditto->paginate()
 
         if (is_array($tpl)) {
-            $tpl = join('', $tpl);
+            $tpl = implode('', $tpl);
         }
 
         if (strpos($tpl, '@') === 0) {
@@ -5202,7 +5202,7 @@ class DocumentParser
                 if ($tvtype === 'checkbox' || $tvtype === 'listbox-multiple') {
                     // add separator
                     $value = explode('||', $value);
-                    $value = join($sep, $value);
+                    $value = implode($sep, $value);
                 }
                 $o = $value;
                 break;
@@ -5370,7 +5370,7 @@ class DocumentParser
         }
         return str_ireplace(
             '</body>',
-            join("\n", $this->jscripts) . "\n</body>",
+            implode("\n", $this->jscripts) . "\n</body>",
             $content
         );
     }
@@ -5382,19 +5382,19 @@ class DocumentParser
         }
         return str_ireplace(
             '</head>',
-            join("\n", $this->sjscripts) . "\n</head>",
+            implode("\n", $this->sjscripts) . "\n</head>",
             $content
         );
     }
 
     public function getRegisteredClientScripts()
     {
-        return join("\n", $this->jscripts);
+        return implode("\n", $this->jscripts);
     }
 
     public function getRegisteredClientStartupScripts()
     {
-        return join("\n", $this->sjscripts);
+        return implode("\n", $this->sjscripts);
     }
 
     /**

--- a/manager/includes/docvars/outputfilter/htmltag.inc.php
+++ b/manager/includes/docvars/outputfilter/htmltag.inc.php
@@ -22,7 +22,7 @@ foreach ($values as $value) {
         if ($v) $_[] = "{$k}=\"{$v}\"";
     }
     if ($params['tagattrib']) $_[] = $params['tagattrib']; // add extra
-    $attributes = join(' ', $_);
+    $attributes = implode(' ', $_);
     if ($attributes !== '') $attributes = ' ' . $attributes;
 
     // Output the HTML Tag

--- a/manager/includes/extenders/ex_deprecated.php
+++ b/manager/includes/extenders/ex_deprecated.php
@@ -183,7 +183,7 @@ class OldFunctions
                     }
                     $_ = array_reverse($_);
                 }
-                $key = join('/', $_);
+                $key = implode('/', $_);
             }
             $modx->documentListing[$key] = $docid;
             $str = "<?php\n// Deprecated since 1.0.6\nreturn " . var_export($modx->documentListing, true) . ';';

--- a/manager/includes/extenders/ex_export_site.php
+++ b/manager/includes/extenders/ex_export_site.php
@@ -76,7 +76,7 @@ class EXPORT_SITE
                 $v = db()->escape(trim($v));
                 $allow_ids[$i] = "'{$v}'";
             }
-            $allow_ids = join(',', $allow_ids);
+            $allow_ids = implode(',', $allow_ids);
             $allow_ids = "AND id IN ({$allow_ids})";
         }
         if ($ignore_ids !== '') {
@@ -85,7 +85,7 @@ class EXPORT_SITE
                 $v = db()->escape(trim($v));
                 $ignore_ids[$i] = "'{$v}'";
             }
-            $ignore_ids = join(',', $ignore_ids);
+            $ignore_ids = implode(',', $ignore_ids);
             $ignore_ids = "AND NOT id IN ({$ignore_ids})";
         }
 
@@ -274,7 +274,7 @@ class EXPORT_SITE
             unlink($this->lock_file_path);
         }
 
-        return join("\n", $this->output);
+        return implode("\n", $this->output);
     }
 
     private function processRow($row, $target_base_path, $_lang, $mask)

--- a/manager/includes/extenders/ex_maketable.php
+++ b/manager/includes/extenders/ex_maketable.php
@@ -388,7 +388,7 @@ EOT;
         if (empty($navlink)) {
             return '';
         }
-        return sprintf('<div id="pagination" class="paginate"><ul>%s</ul></div>', join("\n", $navlink));
+        return sprintf('<div id="pagination" class="paginate"><ul>%s</ul></div>', implode("\n", $navlink));
     }
 
     /**

--- a/manager/includes/extenders/ex_managerapi.php
+++ b/manager/includes/extenders/ex_managerapi.php
@@ -622,7 +622,7 @@ class ManagerAPI
         if (!isset($ph['tab-pages'])) {
             $ph['tab-pages'] = 'content';
         } elseif (is_array($ph['tab-pages'])) {
-            $ph['tab-pages'] = join("\n", $ph['tab-pages']);
+            $ph['tab-pages'] = implode("\n", $ph['tab-pages']);
         }
 
         return evo()->parseText(

--- a/manager/includes/extenders/modifiers/mdf_addbreak.inc.php
+++ b/manager/includes/extenders/modifiers/mdf_addbreak.inc.php
@@ -18,4 +18,4 @@ foreach ($lines as $i => $line) {
     }
     $lines[$i] = "{$line}<br />";
 }
-return join("\n", $lines);
+return implode("\n", $lines);

--- a/manager/includes/traits/document.parser.subparser.trait.php
+++ b/manager/includes/traits/document.parser.subparser.trait.php
@@ -2181,7 +2181,7 @@ trait DocumentParserSubParserTrait
             if ($access !== '') {
                 $access .= ' OR';
             }
-            $access .= sprintf(' dg.document_group IN (%s)', join(',', $docgrp));
+            $access .= sprintf(' dg.document_group IN (%s)', implode(',', $docgrp));
         }
 
         $_ = [];
@@ -2194,7 +2194,7 @@ trait DocumentParserSubParserTrait
         if ($access != '') {
             $_[] = "({$access})";
         }
-        $where = join(' AND ', $_) . ' GROUP BY sc.id';
+        $where = implode(' AND ', $_) . ' GROUP BY sc.id';
 
         if (strpos($sort, ',') !== false) {
             $orderby = $modx->join(',', explode(',', $sort), 'sc.');

--- a/manager/media/style/RevoStyle/welcome.php
+++ b/manager/media/style/RevoStyle/welcome.php
@@ -245,7 +245,7 @@ function tabOnlineUser()
                 $currentaction
             );
         }
-        if (!empty($tr)) $ph['userlist'] = join("\n", $tr);
+        if (!empty($tr)) $ph['userlist'] = implode("\n", $tr);
         $ph['now'] = date('H:i:s', time() + config('server_offset_time'));
         $tpl = <<< TPL
 <p>[+onlineusers_message+]<b>[+now+]</b>)</p>

--- a/manager/processors/document/delete_content.processor.php
+++ b/manager/processors/document/delete_content.processor.php
@@ -25,7 +25,7 @@ if ($id == $modx->config['site_start']) {
 }
 
 if (isset($linked) && $linked !== false) {
-    $warning = 'Linked by ' . 'ID:' . join(', ID:', $linked);
+    $warning = 'Linked by ' . 'ID:' . implode(', ID:', $linked);
 }
 
 if (isset($warning)) {

--- a/manager/processors/document/save_resource.processor.php
+++ b/manager/processors/document/save_resource.processor.php
@@ -653,7 +653,7 @@ function update_tmplvars($docid, $tmplvars)
     if ($tvDeletions) {
         db()->delete(
             '[+prefix+]site_tmplvar_contentvalues',
-            'id IN(' . join(',', $tvDeletions) . ')'
+            'id IN(' . implode(',', $tvDeletions) . ')'
         );
     }
     if ($tvAdded) {


### PR DESCRIPTION
PHPのjoin()関数は非推奨のエイリアスであるため、すべての使用箇所を
implode()関数に置き換えました。

変更内容:
- install/actions/options.php: 4箇所
- manager/frames/menu.php: 7箇所
- manager/frames/nodes.php: 2箇所
- manager/processors内のファイル: 2箇所
- manager/includes/traits内のファイル: 2箇所
- manager/includes/document.parser.class.inc.php: 13箇所
- manager/includes/cache_sync.class.php: 1箇所
- manager/includes/extenders内のファイル: 6箇所
- manager/actions内のファイル: 15箇所
- assets内のファイル: 10箇所

注: JavaScriptコード内のjoin()メソッドと、$modx->join()などの
クラスメソッド呼び出しは変更していません。

@codex 日本語でレビュー