### PR TITLE
fix: explode()へのnullパラメータ渡しによるPHP 8非推奨警告を修正

### DIFF
--- a/manager/actions/document/mutate_content/fields.php
+++ b/manager/actions/document/mutate_content/fields.php
@@ -691,7 +691,11 @@ function fieldContentType()
     if (doc('type') === 'reference') {
         return '';
     }
-    $ct = explode(',', config('custom_contenttype'));
+    $custom_contenttype = config('custom_contenttype');
+    if (!$custom_contenttype) {
+        return '';
+    }
+    $ct = explode(',', $custom_contenttype);
     $option = [];
     foreach ($ct as $value) {
         $option[] = html_tag(


### PR DESCRIPTION
## 概要
fieldContentType()関数で、explode()の第2引数にnullが渡されることによるPHP 8の非推奨警告を修正しました。

## 問題

```
Deprecated: explode(): Passing null to parameter #2 ($string) of type string is deprecated
```
config('custom_contenttype') が null を返す場合、explode() に null が渡されてPHP 8で非推奨警告が発生していました。

## 修正内容
- config('custom_contenttype') の戻り値を変数に格納
- 値が null または空の場合は早期 return で対処し、explode() を実行しないように修正

## 変更ファイル
- manager/actions/document/mutate_content/fields.php

## テスト
- [ ] custom_contenttypeが設定されている場合の動作確認
- [ ] custom_contenttypeが未設定(null)の場合の動作確認
- [ ] PHP 8環境での非推奨警告が出ないことを確認