### PR TITLE
Fix manager navigation alignment

### DIFF
--- a/manager/media/style/RevoStyle/style.css
+++ b/manager/media/style/RevoStyle/style.css
@@ -975,7 +975,7 @@ a.hometblink:hover {
 
 #nav {
     display: flex;
-    align-items: flex-start;
+    align-items: flex-end;
     justify-content: flex-start;
     gap: var(--topnav-gap);
     margin: 0;
@@ -1048,6 +1048,7 @@ a.hometblink:hover {
 
 #nav > li > ul.subnav > li {
     margin: 0;
+    list-style: none;
 }
 
 #nav > li > ul.subnav a {


### PR DESCRIPTION
## Summary
- align the top navigation tabs with the toolbar background to restore the intended layout
- remove residual list markers from sub navigation items so they render cleanly

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ffd6670a4832db76614d43b8a774d)