### PR TITLE
Prevent installer cleanup from counting null ID arrays

### DIFF
--- a/install/functions.php
+++ b/install/functions.php
@@ -245,8 +245,8 @@ function clean_up($table_prefix)
                     implode(', ', $ids)
                 )
             );
-            unset($ids);
         }
+        $ids = [];
     }
 
     // secure manager documents privatemgr
@@ -282,8 +282,8 @@ function clean_up($table_prefix)
                     $ids
                 )
             );
-            unset($ids);
         }
+        $ids = [];
     }
 }
 


### PR DESCRIPTION
## Summary
- reset the collected document IDs after each cleanup query to keep the array defined

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911bfbcc764832db676785e1206a11d)