### PR TITLE
Use getv helper for GET parameter handling

### DIFF
--- a/assets/snippets/ditto/classes/ditto.class.inc.php
+++ b/assets/snippets/ditto/classes/ditto.class.inc.php
@@ -1123,7 +1123,7 @@ class ditto
         global $dittoID;
         $dittoID = ($dittoIdentifier !== false) ? $dittoIdentifier : $dittoID;
         $query = [];
-        foreach ($_GET as $param => $value) {
+        foreach (getv() as $param => $value) {
             if ($param !== 'id' && $param !== 'q') {
                 $clean_param = hsc($param, ENT_QUOTES);
                 if (is_array($value)) {
@@ -1211,7 +1211,7 @@ class ditto
         if ($previous != 0) {
             $prevUrl = self::buildURL('start=' . $previous);
         } else {
-            $args = $_GET;
+            $args = getv();
             if (isset($args[$dittoID . 'start'])) {
                 unset($args[$dittoID . 'start']);
             }

--- a/assets/snippets/ditto/debug/modxDebugConsole.class.php
+++ b/assets/snippets/ditto/debug/modxDebugConsole.class.php
@@ -81,7 +81,7 @@ class modxDebugConsole
     {
         global $modx;
         $query = [];
-        foreach ($_GET as $param => $value) {
+        foreach (getv() as $param => $value) {
             if ($param !== 'id' && $param !== 'q') {
                 $query[htmlspecialchars($param, ENT_QUOTES)] = htmlspecialchars($value, ENT_QUOTES);
             }

--- a/assets/snippets/weblogin/weblogin.common.inc.php
+++ b/assets/snippets/weblogin/weblogin.common.inc.php
@@ -70,7 +70,7 @@ function webLoginSendNewPassword($email, $uid, $pwd, $ufn)
 function preserveUrl($docid = '', $alias = '', $array_values = [], $suffix = false)
 {
     global $modx;
-    $array_get = $_GET;
+    $array_get = getv();
     $urlstring = [];
 
     unset($array_get['id'], $array_get['q'], $array_get['webloginmode']);

--- a/index.php
+++ b/index.php
@@ -9,7 +9,7 @@ if (defined('IN_MANAGER_MODE')) {
     return;
 }
 
-if ($_GET['get']??'' === 'captcha') {
+if (getv('get') === 'captcha') {
     include_once MODX_BASE_PATH . 'manager/media/captcha/veriword.php';
     return;
 }

--- a/manager/actions/document/mutate_content/functions.php
+++ b/manager/actions/document/mutate_content/functions.php
@@ -497,7 +497,8 @@ function checkPermissions($id)
     global $modx;
 
     $isAllowed = manager()->isAllowed($id);
-    if (!isset($_GET['pid']) && !$isAllowed) {
+    $request = getv();
+    if (!array_key_exists('pid', $request) && !$isAllowed) {
         alert()->setError(3);
         alert()->dumpError();
     }

--- a/manager/includes/controls/datasetpager.class.php
+++ b/manager/includes/controls/datasetpager.class.php
@@ -152,7 +152,7 @@ class DataSetPager
                     $url = $_SERVER['PHP_SELF'] . '?';
                 }
                 $i = 0;
-                foreach ($_GET as $n => $v) {
+                foreach (getv() as $n => $v) {
                     if ($n != 'dpgn' . $this->id) {
                         $i++;
                         $url .= (($i > 1) ? "&" : "") . "$n=$v";

--- a/manager/includes/document.parser.class.inc.php
+++ b/manager/includes/document.parser.class.inc.php
@@ -326,7 +326,7 @@ class DocumentParser
         if (strpos($uri, '?') === false) {
             return $uri;
         }
-        $qs = $this->removeTrackingParameters($_GET);
+        $qs = $this->removeTrackingParameters(getv());
         ksort($qs);
         return strstr($uri, '?', true) . '?' . http_build_query($qs);
     }
@@ -485,7 +485,9 @@ class DocumentParser
                 $_SERVER[$key] = null;
             }
         }
-        $this->sanitize_gpc($_GET);
+        $get = getv();
+        $this->sanitize_gpc($get);
+        globalv('*_GET', $get);
         if ($this->isBackend()) {
             if (session_id() === '' || $this->session('mgrPermissions.save_document') != 1) {
                 $this->sanitize_gpc($_POST);
@@ -509,7 +511,7 @@ class DocumentParser
             return '';
         }
 
-        $qs = $_GET;
+        $qs = getv();
         if (isset($qs['id'])) {
             unset($qs['id']);
         }
@@ -5806,7 +5808,7 @@ class DocumentParser
 
     public function input_get($key = null, $default = null)
     {
-        return $this->array_get($_GET, $key, $default);
+        return getv($key, $default);
     }
 
     public function input_post($key = null, $default = null)

--- a/manager/media/browser/mcpuk/connectors/connector.php
+++ b/manager/media/browser/mcpuk/connectors/connector.php
@@ -46,7 +46,7 @@ $modx->getSettings();
 global $fckphp_config;
 include_once __DIR__ . '/config.php';
 
-$request = ConnectorRequest::fromGlobals($_GET, $_POST, $_FILES, $_SERVER, $_COOKIE);
+$request = ConnectorRequest::fromGlobals(getv(), $_POST, $_FILES, $_SERVER, $_COOKIE);
 $kernel = new ConnectorKernel($modx, $fckphp_config, __DIR__ . '/Commands');
 
 $kernel->handle($request, isset($_SESSION) ? $_SESSION : []);

--- a/manager/processors/module/save_module.processor.php
+++ b/manager/processors/module/save_module.processor.php
@@ -57,8 +57,8 @@ switch (postv('mode')) {
             // prepare a few variables prior to redisplaying form...
             $content = [];
             $_REQUEST['a'] = '107';
-            $_GET['a'] = '107';
-            $_GET['stay'] = postv('stay');
+            globalv('*_GET.a', '107');
+            globalv('*_GET.stay', postv('stay'));
             $content = array_merge($content, $_POST);
             $content['wrap'] = $wrap;
             $content['disabled'] = $disabled;

--- a/manager/processors/plugin/save_plugin.processor.php
+++ b/manager/processors/plugin/save_plugin.processor.php
@@ -67,8 +67,8 @@ switch (postv('mode')) {
                 // prepare a few variables prior to redisplaying form...
                 $content = [];
                 $_REQUEST['a'] = '101';
-                $_GET['a'] = '101';
-                $_GET['stay'] = postv('stay');
+                globalv('*_GET.a', '101');
+                globalv('*_GET.stay', postv('stay'));
                 $content = array_merge($content, $_POST);
                 $content['locked'] = $locked;
                 $content['plugincode'] = postv('post');
@@ -136,8 +136,8 @@ switch (postv('mode')) {
                 // prepare a few variables prior to redisplaying form...
                 $content = [];
                 $_REQUEST['a'] = '102';
-                $_GET['a'] = '102';
-                $_GET['stay'] = postv('stay');
+                globalv('*_GET.a', '102');
+                globalv('*_GET.stay', postv('stay'));
                 $content = array_merge($content, $_POST);
                 $content['locked'] = $locked;
                 $content['plugincode'] = postv('post');

--- a/manager/processors/remove_installer.processor.php
+++ b/manager/processors/remove_installer.processor.php
@@ -14,7 +14,7 @@ $self = 'manager/processors/remove_installer.processor.php';
 $base_path = str_replace(['\\', $self], ['/', ''], __FILE__);
 
 $install_dir = "{$base_path}install";
-if ($_GET['rminstall']??null) {
+if (getv('rminstall')) {
     if (is_dir($install_dir)) {
         if (!rmdirRecursive($install_dir)) {
             $msg = 'An error occured while attempting to remove the install folder';

--- a/manager/processors/template/save_template.processor.php
+++ b/manager/processors/template/save_template.processor.php
@@ -63,7 +63,7 @@ switch (postv('mode')) {
             $_REQUEST['a'] = '19';
             $_POST['locked'] = postv('locked') == 'on' ? 1 : 0;
             $_POST['category'] = $categoryid;
-            $_GET['stay'] = postv('stay');
+            globalv('*_GET.stay', postv('stay'));
             include(MODX_MANAGER_PATH . 'actions/header.inc.php');
             include(MODX_MANAGER_PATH . 'actions/element/mutate_templates.dynamic.php');
             include(MODX_MANAGER_PATH . 'actions/footer.inc.php');
@@ -113,7 +113,7 @@ switch (postv('mode')) {
             $_REQUEST['a'] = '16';
             $_POST['locked'] = postv('locked') == 'on' ? 1 : 0;
             $_POST['category'] = $categoryid;
-            $_GET['stay'] = postv('stay');
+            globalv('*_GET.stay', postv('stay'));
             include(MODX_MANAGER_PATH . 'actions/header.inc.php');
             include(MODX_MANAGER_PATH . 'actions/element/mutate_templates.dynamic.php');
             include(MODX_MANAGER_PATH . 'actions/footer.inc.php');


### PR DESCRIPTION
## Summary
- replace direct $_GET reads with the getv() helper across frontend and manager code
- sanitize and persist GET data through getv() before reuse in DocumentParser
- route internal redirects that mutate GET values through globalv() to avoid superglobal access

## Testing
- php -l on modified PHP files

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691469dbc9e8832d9f503e1042e4d3d2)