### PR TITLE
Add layered background styling for SoftSlate UI

### DIFF
--- a/manager/media/style/RevoStyle/style.css
+++ b/manager/media/style/RevoStyle/style.css
@@ -6,7 +6,7 @@ html, body, form, fieldset {
 
 :root {
     --color-text-primary: #333;
-    --color-background-page: #f4f4f4;
+    --color-background-page: #edf1f7;
     --color-link: #1285a4;
     --color-link-hover: #0f1e76;
     --color-border-default: #ccc;
@@ -37,7 +37,7 @@ body {
     height: 100%;
     line-height: 1.5;
     color: var(--color-text-primary);
-    background: var(--color-background-page);
+    background: linear-gradient(180deg, #f5f7fa 0%, #edf1f7 100%);
 }
 
 img, a img {
@@ -598,6 +598,43 @@ form .imeoff {
     position: inherit;
 }
 
+.content {
+    background: none;
+}
+
+#create_edit {
+    background: #ffffff;
+    border: 1px solid rgba(15, 23, 42, 0.05);
+    border-radius: 10px;
+    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
+    padding: 12px 18px 18px;
+    margin: 10px 0 20px;
+}
+
+#create_edit > h1 {
+    margin: 0 0 10px;
+}
+
+#create_edit .sectionBody {
+    background: #f8fafc;
+    border: 1px solid rgba(15, 23, 42, 0.06);
+    border-radius: 8px;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+#create_edit .dynamic-tab-pane-control .tab-row {
+    background: #f8fafc;
+    border-bottom: 1px solid rgba(15, 23, 42, 0.06);
+    border-radius: 8px 8px 0 0;
+    padding: 2px 12px 8px;
+}
+
+#create_edit .dynamic-tab-pane-control .tab-page {
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    border-radius: 0 0 10px 10px;
+    box-shadow: 0 8px 20px rgba(15, 23, 42, 0.03);
+}
+
 .section .sectionBody {
     margin: 0 15px 15px;
     background-color: var(--color-surface);
@@ -686,8 +723,9 @@ a img {
 }
 
 div.treeframebody {
-    background: #f5f5f5 url(images/misc/subnav.png) !important;
-    box-shadow: inset -2px 2px 6px 0px rgba(0, 0, 0, 0.1);
+    background: #f2f4f8;
+    border-right: 1px solid rgba(15, 23, 42, 0.08);
+    box-shadow: inset -1px 0 0 rgba(15, 23, 42, 0.04);
 }
 
 #treeMenu * {
@@ -700,9 +738,7 @@ div.treeframebody {
     padding: 6px 8px 0;
     line-height: 1.3em;
     font-family: Arial, "Helvetica Neue", Helvetica, Meiryo, "Hiragino Kaku Gothic Pro", sans-serif;
-}
-
-#treeHolder {
+    background: #f2f4f8;
     padding-left: 12px;
 }
 
@@ -748,11 +784,16 @@ div.treeNode {
 
 .treeNodeSelected,
 .treeNodeHover {
-    background-color: #FFFFFF;
-    border: 1px solid #CCC;
+    background-color: rgba(59, 130, 246, 0.12);
+    border: 1px solid rgba(59, 130, 246, 0.18);
     color: #000;
     padding: 1px 2px;
     margin-left: -3px;
+}
+
+.treeNodeHover {
+    background-color: rgba(59, 130, 246, 0.08);
+    border-color: rgba(59, 130, 246, 0.14);
 }
 
 .unpublished a, .unpublishedNode {


### PR DESCRIPTION
## Summary
- apply a subtle blue-gray gradient to the manager background
- give the navigation tree its own softly shaded panel with gentler hover and selection accents
- style the edit form container and tabs as a lifted card to emphasize the primary workspace

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921bcdeef64832d818e483517c5f593)