### PR TITLE
Add LytmusBlue manager theme

### DIFF
--- a/manager/media/style/LytmusBlue/config.php.sample
+++ b/manager/media/style/LytmusBlue/config.php.sample
@@ -1,0 +1,15 @@
+<?php
+$tab_your_info   = 1;
+$tab_online      = 1;
+
+$iconResources   = 1;
+$iconNewDoc      = 1;
+$iconSearch      = 1;
+$iconMessage     = 1;
+
+$iconElements    = 1;
+$iconSettings    = 1;
+$iconFileManager = 1;
+$iconEventLog    = 1;
+$iconSysInfo     = 1;
+$iconHelp        = 1;

--- a/manager/media/style/LytmusBlue/index.html
+++ b/manager/media/style/LytmusBlue/index.html
@@ -1,0 +1,2 @@
+<h2>Unauthorized access</h2>
+You're not allowed to access file folder

--- a/manager/media/style/LytmusBlue/login.tpl
+++ b/manager/media/style/LytmusBlue/login.tpl
@@ -1,0 +1,628 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="[+modx_charset+]">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="robots" content="noindex, nofollow">
+    <title>MODX CMF Manager Login</title>
+    <!-- 既存のstyle.cssは読み込まない（独自スタイルを使用） -->
+    <style>
+        /* グラスモーフィズム - 洗練されたログイン画面 */
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        html {
+            height: 100%;
+        }
+
+        html, body {
+            width: 100%;
+            overflow-x: hidden;
+            overflow-y: auto;
+        }
+
+        body {
+            min-height: 100%;
+            position: relative;
+            background: #0a0e1a;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            padding: 40px 20px;
+        }
+
+        /* Option 1: 複雑な多層グラデーション（10層） - より深みのある光の表現 */
+        body::before {
+            content: '';
+            position: absolute;
+            width: 100%;
+            height: 100%;
+            top: 0;
+            left: 0;
+            background: 
+                /* メイン光源 - 中心からの広がり */
+                radial-gradient(ellipse at 50% 45%, rgba(59, 130, 246, 0.20) 0%, rgba(59, 130, 246, 0.12) 15%, rgba(59, 130, 246, 0.06) 30%, transparent 55%),
+                
+                /* 左上の青い光 */
+                radial-gradient(ellipse at 18% 25%, rgba(37, 99, 235, 0.22) 0%, rgba(37, 99, 235, 0.14) 20%, rgba(37, 99, 235, 0.08) 35%, transparent 52%),
+                
+                /* 右下の深い青 */
+                radial-gradient(ellipse at 82% 75%, rgba(30, 64, 175, 0.24) 0%, rgba(30, 64, 175, 0.16) 18%, rgba(30, 64, 175, 0.09) 32%, transparent 50%),
+                
+                /* 左下のシアン系光 */
+                radial-gradient(ellipse at 15% 80%, rgba(14, 165, 233, 0.18) 0%, rgba(14, 165, 233, 0.11) 22%, rgba(14, 165, 233, 0.06) 38%, transparent 54%),
+                
+                /* 右上の紫がかった青 */
+                radial-gradient(ellipse at 85% 20%, rgba(99, 102, 241, 0.16) 0%, rgba(99, 102, 241, 0.10) 25%, rgba(99, 102, 241, 0.05) 42%, transparent 58%),
+                
+                /* 中央やや右の微細な光 */
+                radial-gradient(circle at 65% 55%, rgba(59, 130, 246, 0.09) 0%, rgba(59, 130, 246, 0.05) 25%, transparent 48%),
+                
+                /* 中央やや左の補助光 */
+                radial-gradient(circle at 35% 48%, rgba(37, 99, 235, 0.08) 0%, rgba(37, 99, 235, 0.04) 22%, transparent 45%),
+                
+                /* 右中央の繊細な光 */
+                radial-gradient(ellipse at 88% 50%, rgba(14, 165, 233, 0.07) 0%, rgba(14, 165, 233, 0.04) 28%, transparent 50%),
+                
+                /* 左中央の柔らかい光 */
+                radial-gradient(ellipse at 12% 55%, rgba(30, 64, 175, 0.06) 0%, rgba(30, 64, 175, 0.03) 30%, transparent 52%),
+                
+                /* ベースの複雑なグラデーション */
+                linear-gradient(145deg, 
+                    rgba(37, 99, 235, 0.06) 0%,
+                    rgba(30, 64, 175, 0.05) 12%,
+                    rgba(59, 130, 246, 0.04) 25%,
+                    transparent 38%,
+                    rgba(14, 165, 233, 0.04) 52%,
+                    transparent 65%,
+                    rgba(99, 102, 241, 0.03) 78%,
+                    rgba(59, 130, 246, 0.05) 90%,
+                    rgba(37, 99, 235, 0.07) 100%
+                );
+        }
+
+        /* Option 2: 微細なノイズテクスチャ（フィルムグレイン） */
+        body::after {
+            content: '';
+            position: absolute;
+            width: 100%;
+            height: 100%;
+            top: 0;
+            left: 0;
+            opacity: 0.4;
+            background-image:
+                /* 細かいノイズパターン1 */
+                repeating-radial-gradient(
+                    circle at 20% 30%,
+                    transparent 0,
+                    rgba(255, 255, 255, 0.008) 1px,
+                    transparent 2px,
+                    transparent 3px
+                ),
+                /* 細かいノイズパターン2 */
+                repeating-radial-gradient(
+                    circle at 80% 70%,
+                    transparent 0,
+                    rgba(59, 130, 246, 0.006) 1px,
+                    transparent 2px,
+                    transparent 3px
+                ),
+                /* 微細な横ラインテクスチャ */
+                repeating-linear-gradient(
+                    0deg,
+                    transparent,
+                    transparent 1px,
+                    rgba(255, 255, 255, 0.004) 1px,
+                    rgba(255, 255, 255, 0.004) 2px
+                ),
+                /* 微細な縦ラインテクスチャ */
+                repeating-linear-gradient(
+                    90deg,
+                    transparent,
+                    transparent 1px,
+                    rgba(255, 255, 255, 0.003) 1px,
+                    rgba(255, 255, 255, 0.003) 2px
+                ),
+                /* 斜めの微細なテクスチャ */
+                repeating-linear-gradient(
+                    45deg,
+                    transparent,
+                    transparent 2px,
+                    rgba(59, 130, 246, 0.002) 2px,
+                    rgba(59, 130, 246, 0.002) 3px
+                ),
+                /* ベースの柔らかいグラデーション */
+                linear-gradient(
+                    180deg,
+                    rgba(255, 255, 255, 0.01) 0%,
+                    transparent 50%,
+                    rgba(0, 0, 0, 0.02) 100%
+                );
+        }
+
+        /* メインコンテナ */
+        #mx_loginbox {
+            position: relative;
+            z-index: 10;
+            width: 460px;
+            margin: 0;
+        }
+
+        /* ガラス効果のフォームコンテナ */
+        form {
+            position: relative;
+            border-radius: 24px;
+            overflow: hidden;
+            box-shadow: 
+                0 8px 32px 0 rgba(37, 99, 235, 0.2),
+                0 4px 16px 0 rgba(0, 0, 0, 0.4),
+                0 0 0 1px rgba(255, 255, 255, 0.05),
+                inset 0 1px 1px 0 rgba(255, 255, 255, 0.08);
+        }
+
+        /* 内側のグロー効果 */
+        form::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            height: 1px;
+            background: linear-gradient(90deg, 
+                transparent,
+                rgba(255, 255, 255, 0.1) 30%,
+                rgba(255, 255, 255, 0.1) 70%,
+                transparent
+            );
+        }
+
+        /* ヘッダー */
+        .header {
+            background: rgba(20, 24, 38, 0.6);
+            backdrop-filter: blur(20px) saturate(180%);
+            -webkit-backdrop-filter: blur(20px) saturate(180%);
+            padding: 24px;
+            border-bottom: 1px solid rgba(37, 99, 235, 0.1);
+            position: relative;
+        }
+
+        .header::after {
+            content: '';
+            position: absolute;
+            bottom: 0;
+            left: 10%;
+            right: 10%;
+            height: 1px;
+            background: linear-gradient(90deg,
+                transparent,
+                rgba(59, 130, 246, 0.3),
+                transparent
+            );
+        }
+
+        .header a {
+            color: rgba(255, 255, 255, 0.95);
+            text-decoration: none;
+            font-size: 18px;
+            font-weight: 600;
+            letter-spacing: 0.5px;
+            transition: all 0.3s ease;
+            display: inline-block;
+            opacity: 0.7;
+        }
+
+        .header a:hover {
+            color: rgba(59, 130, 246, 1);
+            text-shadow: 0 0 20px rgba(59, 130, 246, 0.5);
+            opacity: 1;
+        }
+
+        /* ボディ */
+        .body {
+            font-family: Helvetica, sans-serif;
+            background: rgba(15, 18, 30, 0.55);
+            backdrop-filter: blur(50px) saturate(160%);
+            -webkit-backdrop-filter: blur(50px) saturate(160%);
+            padding: 24px;
+            position: relative;
+            box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+        }
+
+        /* ロゴ - 非表示 */
+        #logo {
+            display: none;
+        }
+
+        /* ラベル - 左揃え */
+        label {
+            display: block;
+            color: rgba(255, 255, 255, 0.85);
+            font-size: 13px;
+            font-weight: 500;
+            margin-bottom: 8px;
+            letter-spacing: 0.3px;
+            text-align: left;
+        }
+
+        /* 最初のラベル（ログイン名）は上マージンなし */
+        label[for="username"] {
+            margin-top: 0;
+        }
+
+        /* パスワードラベルに上マージン */
+        label[for="password"] {
+            margin-top: 16px;
+        }
+
+        /* インプットフィールド */
+        input.text,
+        input[type="text"],
+        input[type="password"] {
+            width: 100%;
+            padding: 12px 16px;
+            margin-bottom: 0;
+            background: rgba(30, 35, 55, 0.4);
+            border: 1px solid rgba(37, 99, 235, 0.2);
+            border-radius: 12px;
+            color: rgba(255, 255, 255, 0.95);
+            font-size: 14px;
+            letter-spacing: 3px;
+            transition: all 0.3s ease;
+            backdrop-filter: blur(10px);
+            -webkit-backdrop-filter: blur(10px);
+        }
+
+        /* ユーザー名フィールド */
+        #username {
+            margin-bottom: 0;
+        }
+
+        /* パスワードフィールド */
+        #password {
+            margin-bottom: 0;
+        }
+
+        /* パスワードフィールドラッパー（アイコン配置用） */
+        .password-wrapper {
+            position: relative;
+        }
+
+        /* パスワード表示/非表示切り替えアイコン */
+        .toggle-password {
+            position: absolute;
+            right: 12px;
+            top: 50%;
+            transform: translateY(-50%);
+            cursor: pointer;
+            font-size: 20px;
+            user-select: none;
+            opacity: 0.5;
+            transition: opacity 0.3s ease;
+            z-index: 10;
+        }
+
+        .toggle-password:hover {
+            opacity: 0.8;
+        }
+
+        /* オートフィル時の黄色背景を上書き */
+        input.text:-webkit-autofill,
+        input[type="text"]:-webkit-autofill,
+        input[type="password"]:-webkit-autofill {
+            -webkit-box-shadow: 0 0 0 1000px rgba(30, 35, 55, 0.9) inset !important;
+            -webkit-text-fill-color: rgba(255, 255, 255, 0.95) !important;
+            border: 1px solid rgba(59, 130, 246, 0.4) !important;
+            transition: background-color 5000s ease-in-out 0s;
+        }
+
+        input.text:-webkit-autofill:focus,
+        input[type="text"]:-webkit-autofill:focus,
+        input[type="password"]:-webkit-autofill:focus {
+            -webkit-box-shadow: 0 0 0 1000px rgba(30, 35, 55, 0.95) inset !important;
+            border: 1px solid rgba(59, 130, 246, 0.5) !important;
+        }
+
+        input.text::placeholder,
+        input[type="text"]::placeholder,
+        input[type="password"]::placeholder {
+            color: rgba(255, 255, 255, 0.3);
+        }
+
+        input.text:focus,
+        input[type="text"]:focus,
+        input[type="password"]:focus {
+            outline: none;
+            background: rgba(30, 35, 55, 0.6);
+            border-color: rgba(59, 130, 246, 0.5);
+            box-shadow: 
+                0 0 0 3px rgba(59, 130, 246, 0.1),
+                0 4px 12px rgba(37, 99, 235, 0.15);
+        }
+
+        /* Captcha画像 - 左寄せ */
+        img.loginCaptcha {
+            border: 1px solid rgba(37, 99, 235, 0.2);
+            border-radius: 8px;
+            margin: 0 0 8px 0;
+            width: 148px;
+            height: 60px;
+            display: block;
+        }
+
+        /* Captcha入力フィールド */
+        input[name="captcha_code"] {
+            margin-bottom: 0;
+        }
+
+        /* Captchaラベルに上マージン */
+        label[for="captcha_code"] {
+            margin-top: 16px;
+        }
+
+        /* チェックボックスセクション全体の上マージン */
+        .password-wrapper {
+            margin-bottom: 24px;
+        }
+
+        /* チェックボックス - 左揃え */
+        input.checkbox {
+            display: inline-block;
+            margin-right: 8px;
+            margin-top: 0;
+            margin-bottom: 0;
+            width: 16px;
+            height: 16px;
+            cursor: pointer;
+            vertical-align: middle;
+        }
+
+        label[for="rememberme"] {
+            color: rgba(255, 255, 255, 0.7);
+            font-size: 13px;
+            cursor: pointer;
+            display: inline;
+            margin-top: 0;
+            margin-bottom: 0;
+            line-height: 20px;
+            vertical-align: middle;
+        }
+
+        /* ログインボタン - ガラス効果で質感を統一、センタリング */
+        input.login,
+        input[type="submit"] {
+            width: 100%;
+            max-width: 360px;
+            display: block;
+            margin: 24px auto 0;
+            padding: 16px 32px;
+            background: rgba(37, 99, 235, 0.15);
+            backdrop-filter: blur(20px) saturate(180%);
+            -webkit-backdrop-filter: blur(20px) saturate(180%);
+            border: 1px solid rgba(59, 130, 246, 0.4);
+            border-radius: 12px;
+            color: rgba(255, 255, 255, 0.95);
+            font-size: 14px;
+            font-weight: 600;
+            cursor: pointer;
+            transition: all 0.3s ease;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            box-shadow: 
+                0 4px 16px rgba(37, 99, 235, 0.15),
+                inset 0 1px 0 rgba(255, 255, 255, 0.1),
+                0 0 0 0 rgba(59, 130, 246, 0);
+        }
+
+        input.login:hover,
+        input[type="submit"]:hover {
+            background: rgba(37, 99, 235, 0.25);
+            border-color: rgba(59, 130, 246, 0.6);
+            box-shadow: 
+                0 6px 24px rgba(37, 99, 235, 0.25),
+                inset 0 1px 0 rgba(255, 255, 255, 0.15),
+                0 0 20px rgba(59, 130, 246, 0.3);
+            transform: translateY(-1px);
+        }
+
+        input.login:active,
+        input[type="submit"]:active {
+            transform: translateY(0);
+            background: rgba(37, 99, 235, 0.3);
+            box-shadow: 
+                0 2px 8px rgba(37, 99, 235, 0.2),
+                inset 0 1px 0 rgba(255, 255, 255, 0.1),
+                0 0 12px rgba(59, 130, 246, 0.2);
+        }
+
+        /* メッセージ - 左揃え */
+        .loginMessage {
+            font-size: 13px;
+            color: rgba(255, 255, 255, 0.6);
+            padding-bottom: 0;
+            margin-bottom: 16px;
+            line-height: 1.6;
+            text-align: left;
+        }
+
+        /* プラグインで追加されるリンク（パスワード忘れなど） - センタリング */
+        .body a {
+            color: rgba(59, 130, 246, 0.85);
+            text-decoration: none;
+            font-size: 13px;
+            transition: all 0.3s ease;
+            display: block;
+            text-align: center;
+            margin-top: 24px;
+        }
+
+        .body a:hover {
+            color: rgba(59, 130, 246, 1);
+            text-shadow: 0 0 8px rgba(59, 130, 246, 0.4);
+        }
+
+        .warning {
+            color: rgba(251, 113, 133, 0.9);
+            font-weight: 500;
+            padding: 12px;
+            background: rgba(251, 113, 133, 0.1);
+            border-left: 3px solid rgba(251, 113, 133, 0.5);
+            border-radius: 6px;
+            margin-bottom: 16px;
+            text-align: left;
+        }
+
+        .success {
+            color: rgba(74, 222, 128, 0.9);
+            font-weight: 500;
+            padding: 12px;
+            background: rgba(74, 222, 128, 0.1);
+            border-left: 3px solid rgba(74, 222, 128, 0.5);
+            border-radius: 6px;
+            margin-bottom: 16px;
+            text-align: left;
+        }
+
+        /* フッター */
+        .loginLicense {
+            text-align: center;
+            color: rgba(255, 255, 255, 0.3);
+            font-size: 12px;
+            margin-top: 32px;
+            padding: 0;
+            line-height: 1.6;
+            max-width: 460px;
+            width: 100%;
+        }
+
+        .loginLicense a {
+            color: rgba(59, 130, 246, 0.6);
+            text-decoration: none;
+            transition: color 0.3s ease;
+        }
+
+        .loginLicense a:hover {
+            color: rgba(59, 130, 246, 0.9);
+        }
+
+        /* レスポンシブ対応 */
+        @media (max-width: 520px) {
+            body {
+                padding: 24px 16px;
+            }
+
+            #mx_loginbox {
+                width: 100%;
+                max-width: 400px;
+            }
+
+            .header {
+                padding: 24px;
+            }
+
+            .body {
+                padding: 24px;
+            }
+
+            input.text,
+            input[type="text"],
+            input[type="password"] {
+                font-size: 16px; /* iOS ズーム防止 */
+            }
+
+            input.login,
+            input[type="submit"] {
+                max-width: 100%;
+            }
+
+            .loginLicense {
+                margin-top: 24px;
+                max-width: 400px;
+            }
+        }
+    </style>
+
+    <script src="media/script/jquery/jquery.min.js" type="text/javascript"></script>
+    <link rel="stylesheet" href="media/script/jquery/jquery.alerts.css" type="text/css"/>
+    <script src="media/script/jquery/jquery.alerts.js" type="text/javascript"></script>
+
+    <script type="text/javascript">
+        if (top.frames.length != 0) {
+            top.location = self.document.location;
+        }
+    </script>
+</head>
+<body id="login">
+<div id="mx_loginbox">
+    <form method="post" name="loginfrm" id="loginfrm" action="processors/login.processor.php">
+        <!-- anything to output before the login box via a plugin? -->
+        [+OnManagerLoginFormPrerender+]
+        <div class="header"><a href="../">[+site_name+]</a></div>
+        <div class="body">
+            <img src="[+style_misc_path+]login-logo.png" alt="[+site_name+]" id="logo"/>
+            <p class="loginMessage">[+login_message+]</p>
+            <label for="username">[+username+]</label>
+            <input type="text" class="text" name="username" id="username" tabindex="1" value="[+uid+]"/>
+            <label for="password">[+password+]</label>
+            <div class="password-wrapper">
+                <input type="password" class="text" name="password" id="password" tabindex="2" value=""/>
+                <span class="toggle-password" onclick="togglePassword()">👁️</span>
+            </div>
+            [+login_captcha_message+]
+            [+captcha_image+]
+            [+captcha_input+]
+            <input type="checkbox" id="rememberme" name="rememberme" tabindex="4" value="1" class="checkbox"
+                   [+remember_me+]/><label for="rememberme">[+remember_username+]</label>
+            <input type="submit" class="login" onclick="return false;" id="submitButton" value="[+login_button+]"/>
+            <!-- anything to output before the login box via a plugin ... like the forgot password link? -->
+            [+OnManagerLoginFormRender+]
+        </div>
+    </form>
+</div>
+<!-- close #mx_loginbox -->
+
+<!-- convert this to a language include -->
+<p class="loginLicense">
+    &copy; 2005-[[$_SERVER['REQUEST_TIME']:date(Y)]] by the <a href="http://modx.com/" target="_blank">MODX</a>.
+    <strong>MODX</strong>&trade; is licensed under the GPL.
+</p>
+<script>
+    // パスワード表示/非表示切り替え
+    function togglePassword() {
+        var passwordField = document.getElementById('password');
+        var toggleIcon = document.querySelector('.toggle-password');
+        
+        if (passwordField.type === 'password') {
+            passwordField.type = 'text';
+            toggleIcon.textContent = '🙈'; // 非表示アイコン
+        } else {
+            passwordField.type = 'password';
+            toggleIcon.textContent = '👁️'; // 表示アイコン
+        }
+    }
+
+    $('#submitButton').click(function (e) {
+        var $form = $('#loginfrm');
+        var username = $('#username').val();
+        var password = $('#password').val();
+        var rememberme = $('#rememberme').val();
+        var captcha_code = $('input[name="captcha_code"]').val();
+        params = {'username':username,'password':password,'rememberme':rememberme,'ajax':'1','captcha_code':captcha_code};
+        $.post('processors/login.processor.php', params, function (response) {
+            var header = response.substr(0, 9);
+            if (header.toLowerCase() == 'location:') top.location = response.substr(10);
+            else {
+                var cimg = document.getElementById('captcha_image');
+                if (cimg) cimg.src = '../index.php?get=captcha';
+                jAlert(response);
+            }
+        });
+    });
+    if ($('#username').val() != '') $('#password').focus();
+    else $('#username').focus();
+</script>
+</body>
+</html>

--- a/manager/media/style/LytmusBlue/manager.lockout.tpl
+++ b/manager/media/style/LytmusBlue/manager.lockout.tpl
@@ -1,0 +1,86 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<head>
+    <title>MODX Content Manager</title>
+    <meta http-equiv="content-type" content="text/html; charset=[+modx_charset+]"/>
+    <meta name="robots" content="noindex, nofollow"/>
+    <style type="text/css">
+        /* Neutralize styles, fonts and viewport:
+        ---------------------------------------------------------------- */
+        html, body, form, fieldset {margin: 0;padding: 0;border:none;} fieldset {margin-top:20px;} html {background-color:#f4f4f4;
+	font-size: 100.01%; /* avoids obscure font-size bug */
+	line-height: 1.5; /* http://meyerweb.com/eric/thoughts/2006/02/08/unitless-line-heights/ */
+	font-family: Arial, Helvetica, sans-serif;
+	height: 100.01%;color: #333;} body {font-size: 75%; /* 12px 62.5% for 10px*/margin-bottom: 1px; /* avoid jumping scrollbars */background: #F4F4F4;} img, a img {border: 0 !important;text-decoration: none;padding: 0;margin: 0;} input {font:inherit;} p {margin: 0 0 .5em; /* Reset vertical margins on selected elements */padding: 0;} li, dd {margin-left: 1em; /* Left margin only where needed */} .warning{color: #821517;font-weight: bold;} .success{color: #090;font-weight: bold;} a, a:active, a:visited, a:link {color: #333;text-decoration: underline;} a:hover {color: #777;} input, .inputBox {padding: 1px;} form {
+            border: 1px solid #fff;
+        }
+
+        #logo {
+            margin-left: -7px
+        }
+
+        .header {padding: 5px 3px 5px 18px;font-weight: bold;color: #000;background: #EAECEE url([+style_misc_path+]fade.gif) repeat-x top;border-bottom:1px solid #e0e0e0;} .body {padding: 20px 20px 20px;display: block;background: #fff;
+    box-shadow: inset 0px 5px 10px 0px rgba(70, 70, 70, 0.1);} #mx_loginbox {width: 460px;margin: 30px auto 0;
+                                 box-shadow: 0 0 10px #aaa;
+                             -moz-box-shadow: 0 0 10px #aaa;
+                             -webkit-box-shadow: 0 0 15px #ccc;
+} input {margin: 0 0 10px 0;} input.login {float: right;clear: right;margin-right: 0px;padding:5px 8px;cursor: hand; cursor: pointer;background: #EAECEE url([+style_misc_path+]fade.gif) repeat-x top;border:1px solid #ccc;} .loginLicense {width: 460px;color: #B2B2B2;margin: 0.5em auto;font-size: 90%;padding-left: 20px;} .loginLicense a {color: #B2B2B2;} .loginMessage {font-size:12px;color: #999;padding-top: 10px;} #loginfrm
+
+        {background-color:#fff;padding:20px;}
+    </style>
+
+    <script type="text/javascript">
+        function doLogout() {
+            top.location = '[+logouturl+]';
+        }
+
+        function gotoHome() {
+            top.location = '[+homeurl+]';
+        }
+    </script>
+
+    <script type="text/javascript">
+        if (top.frames.length != 0) {
+            top.location = self.document.location;
+        }
+    </script>
+
+</head>
+<body id="login">
+
+<!-- start the login box -->
+<div id="mx_loginbox">
+    <form method="post" name="loginfrm" id="loginfrm" action="processors/login.processor.php">
+
+        <!-- the logo -->
+        <div id="mx_logobox">
+            <img src='[+style_misc_path+]login-logo.png' alt='[+logo_slogan+]'/>
+        </div>
+        <!-- end #mx_logobox -->
+
+        <div id="mx_loginArea">
+            <div class="loginMessage">[+manager_lockout_message+]</div>
+
+            <fieldset id="submitSet">
+                <input type="button" id="submitButton" value="[+home+]" onclick="return gotoHome();"/>&nbsp;
+                <input type="button" id="submitButton" value="[+logout+]" onclick="return doLogout();"/>
+            </fieldset>
+        </div>
+
+        <br style="clear:both;height: 1px"/>
+
+    </form>
+</div>
+<!-- close #mx_loginbox -->
+
+
+<!-- convert this to a language include -->
+<p class="loginLicense">
+    <strong>MODX</strong>&trade; is licensed under the GPL license. &copy; 2005-2012 <a href="http://modx.com/"
+                                                                                        target="_blank">MODX</a>.
+</p>
+
+
+</body>
+</html>

--- a/manager/media/style/LytmusBlue/style.css
+++ b/manager/media/style/LytmusBlue/style.css
@@ -1,0 +1,1969 @@
+/*
+ * ============================================================================
+ * Evolution CMS JP Edition - LytmusBlue Theme
+ * ============================================================================
+ *
+ * TABLE OF CONTENTS:
+ *
+ * 1. CSS Variables & Design Tokens
+ * 2. Base Styles (Reset, Typography, Links)
+ * 3. Utility Classes (hide, clear, status messages)
+ * 4. Typography (Headings, Paragraphs)
+ * 5. Forms (Inputs, Selects, Textareas, Buttons)
+ * 6. Layout Components (Sections, Containers)
+ * 7. Navigation (Top Menu, Supplemental Nav)
+ * 8. Tree Components (Site Tree, Context Menu)
+ * 9. Tables & Grids (Data Tables, Sortable)
+ * 10. Tabs System (Dynamic Tab Pane)
+ * 11. Action Buttons (Fixed Position Controls)
+ * 12. Specialized Forms (Mutate Forms, Date Pickers)
+ * 13. Custom Navigation Gradients
+ *
+ * ============================================================================
+ */
+
+/* ============================================================================
+   1. CSS Variables & Design Tokens
+   Used throughout: All components
+   ============================================================================ */
+
+:root {
+    /* Gray Scale - Core neutral colors */
+    --gray-50: #f6f9fc;
+    --gray-100: #eef3f9;
+    --gray-200: #d9e4ef;
+    --gray-300: #c4d4e5;
+    --gray-400: #b1c4d9;
+    --gray-500: #8fa6bd;
+    --gray-600: #738aa6;
+    --gray-700: #5c738d;
+    --gray-800: #445b73;
+    --gray-900: #1f2f44;
+
+    /* Semantic Colors - Primary theme colors */
+    --color-text-primary: var(--gray-900);
+    --color-text-muted: #5a6b7c;
+    --color-text-subtle: var(--gray-600);
+    --color-text-dark: #13273b;
+    --color-text-darker: #0a1725;
+    --color-background-page: #f4f8fc;
+    --color-link: #0fb3d4;
+    --color-link-hover: #0a8bbf;
+    --color-border-default: #c5d5e4;
+    --color-border-light: #e2ecf5;
+    --color-surface: #fff;
+
+    /* Status Colors */
+    --color-success: #1cbf74;
+    --color-success-light: #30d18a;
+    --color-success-bg: #e6fbf1;
+    --color-error: #de5b64;
+    --color-warning: #f4af2c;
+    --color-info: #2aa4e7;
+
+    /* Component Colors - Sections */
+    --color-section-header-text: var(--color-text-muted);
+    --color-section-header-start: #eef4fb;
+    --color-section-header-end: #d6e4f5;
+    --color-section-bg: #f5f9fd;
+
+    /* Component Colors - Navigation */
+    --color-nav-subnav-start: #0c3c68;
+    --color-nav-subnav-end: #0a2b4f;
+
+    /* Component Colors - Primary Actions */
+    --color-primary: #0fc9d6;
+    --color-primary-start: #0e547f;
+    --color-primary-end: #0a4065;
+    --color-primary-hover-start: #10b8cd;
+    --color-primary-hover-end: #0ba2c0;
+    --color-primary-active-start: #0c92ac;
+    --color-primary-active-end: #0b7b93;
+
+    /* Component Colors - Secondary Actions */
+    --color-secondary-start: #f0f4fa;
+    --color-secondary-end: #e3ecf5;
+    --color-secondary-border: #c6d5e6;
+    --color-secondary-text: #3c5063;
+    --color-secondary-hover-start: #e8f1f9;
+    --color-secondary-hover-end: #d8e7f3;
+    --color-secondary-hover-text: #1f3a52;
+
+    /* Component Colors - Neutral Buttons */
+    --color-neutral-button-start: #f6f9fc;
+    --color-neutral-button-hover-end: #e8f1f8;
+    --color-neutral-button-active-start: #dbe9f3;
+    --color-neutral-button-border: #c3d5e4;
+
+    /* Component Colors - Draft Mode */
+    --color-draft-start: #faf1d4;
+    --color-draft-end: #e9e0c3;
+    --color-draft-light: #F4E2C3;
+
+    /* Spacing Scale - 8px base */
+    --space-1: 4px;
+    --space-2: 8px;
+    --space-3: 12px;
+    --space-4: 16px;
+    --space-5: 20px;
+    --space-6: 24px;
+    --space-8: 32px;
+
+    /* Border Radius */
+    --radius-sm: 3px;
+    --radius-md: 5px;
+    --radius-lg: 8px;
+    --radius-xl: 10px;
+    --radius-full: 999px;
+
+    /* Shadows */
+    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
+    --shadow-md: 1px 1px 3px var(--gray-400);
+    --shadow-lg: 2px 2px 15px #eaeaea;
+    --shadow-inset: inset -2px 2px 6px rgba(0, 0, 0, 0.1);
+
+    /* Transitions */
+    --transition-fast: 0.15s ease;
+    --transition-normal: 0.18s ease;
+    --transition-slow: 0.3s ease;
+}
+
+/* ============================================================================
+   2. Base Styles - Reset & Normalize
+   Used throughout: Global reset
+   ============================================================================ */
+
+html, body, form, fieldset {
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: Meiryo, "Hiragino Kaku Gothic Pro", Arial, "Helvetica Neue", Helvetica, sans-serif;
+    font-size: 75%;
+    height: 100%;
+    line-height: 1.5;
+    color: var(--color-text-primary);
+    background: var(--color-background-page);
+}
+
+body#mainpane {
+    padding: var(--space-2);
+}
+
+img, a img {
+    border: 0 !important;
+    text-decoration: none;
+    padding: 0;
+    margin: 0;
+}
+
+h1, h2, h3, h4, h5, h6, p, pre, blockquote, ul, ol, dl, address {
+    margin: .5em 0;
+    padding: 0;
+    font-weight: normal;
+}
+
+li, dd, blockquote {
+    margin: 0 0 0 1em;
+}
+
+/* ============================================================================
+   3. Utility Classes
+   Used in: Various components for common patterns
+   ============================================================================ */
+
+/* -------------------------[ Miscellaneous conveniences ]--- */
+.clear {
+    clear: both;
+}
+
+.fail {
+    color: var(--color-error);
+    font-weight: bold;
+}
+
+.warning {
+    color: var(--color-warning);
+    font-weight: bold;
+}
+
+.success {
+    color: var(--color-success);
+    font-weight: bold;
+}
+
+.hide, .skip, .printonly {
+    display: none;
+}
+
+.inline {
+    display: inline;
+}
+
+/* ============================================================================
+   4. Typography - Headings & Paragraphs
+   Used in: Page titles, section headers, content areas
+   ============================================================================ */
+
+h1, h2, h3, h4, h5, h6, .subTitle {
+    font-weight: normal;
+}
+
+h1 {
+    font-size: 1.25em;
+    color: var(--gray-800);
+    font-weight: bold;
+    background-color: #d0d0d0;
+    letter-spacing: 1px;
+    line-height: 1em;
+    padding: var(--space-2);
+    border-radius: var(--radius-sm);
+    margin: var(--space-2);
+}
+
+h1.draft {
+    background-color: var(--color-draft-light);
+}
+
+h2 {
+    font-size: 1.64em;
+}
+
+h4,
+h5 {
+    font-size: 1em;
+    font-weight: bold;
+}
+
+h6 {
+    font-size: 0.9em;
+    font-weight: bold;
+}
+
+p.caption, p.comment {
+    font-size: 0.9em;
+    color: var(--gray-600);
+}
+
+button {
+    width: 112px;
+    font: inherit;
+    margin: 0 5px 0 0;
+    cursor: pointer;
+}
+
+a, a:active, a:visited, a:link {
+    color: var(--color-link);
+    text-decoration: underline;
+}
+
+a:hover {
+    color: var(--color-link-hover);
+}
+
+hr {
+    color: var(--gray-700);
+    background-color: var(--gray-700);
+    height: 1px;
+    border: 0;
+}
+
+.split {
+    background: linear-gradient(180deg, #556476 0%, #556476 50%, transparent 50%, transparent 100%);
+    background-size: 100% 1px;
+    height: 1px;
+    font-size: 0;
+    clear: both;
+    padding: 0;
+}
+
+.messageRead {
+    color: var(--color-text-primary);
+}
+
+.messageUnread {
+    color: var(--color-info);
+    font-weight: bold;
+}
+
+.right {
+    font-weight: bold;
+    color: var(--color-text-primary);
+    float: left;
+    padding: 0 var(--space-5) var(--space-5);
+}
+
+/* ============================================================================
+   5. Top Bar & Status Bar
+   Used in: Main navigation frame, status indicators
+   ============================================================================ */
+
+/* -------------------------[ Topbar ]--- */
+#topbar {
+    margin: 0;
+    color: var(--color-text-primary);
+    padding: 0 5px;
+    position: relative;
+}
+
+#topbar * {
+    vertical-align: middle;
+}
+
+#topbar a,
+#topbar a:link,
+#topbar a:visited {
+    font-weight: bold;
+    color: #AAB1B9;
+    text-decoration: none;
+}
+
+#topbar a:hover {
+    color: var(--color-surface);
+}
+
+#tocText {
+    position: absolute;
+    top: 37px;
+    z-index: 1000;
+}
+
+.tocTextRTL {
+    right: 3px;
+}
+
+#tocText,
+#buildText,
+#workText {
+    font-weight: bold;
+    line-height: 16px;
+    margin: 0 15px;
+    color: var(--color-surface);
+}
+
+#tocText,
+#buildText img,
+#workText img {
+    margin: 0 5px;
+}
+
+#statusbar {
+    position: absolute;
+    right: 0;
+    top: 36px;
+    z-index: 1000;
+}
+
+#supplementalNav {
+    align-items: center;
+    background: linear-gradient(180deg, rgba(15, 23, 24, .7), rgba(16, 35, 37, .7));
+    border-radius: var(--radius-full);
+    box-sizing: border-box;
+    color: var(--topnav-link-color);
+    column-gap: var(--topnav-gap);
+    display: flex;
+    font-weight: 500;
+    height: var(--topnav-item-height);
+    line-height: var(--topnav-item-height);
+    margin: 3px 0 0 0;
+    padding: 0 18px;
+    position: absolute;
+    right: var(--subnav-horizontal-padding);
+    top: 6px;
+    z-index: 111;
+}
+
+#supplementalNav a {
+    color: inherit;
+    font-weight: inherit;
+    margin: 0;
+    padding: 0;
+    text-decoration: none;
+    transition: color var(--transition-fast);
+}
+
+#supplementalNav a:hover,
+#supplementalNav a:focus-visible {
+    color: var(--topnav-link-hover-color);
+}
+
+#supplementalNav .supplementalNav__item {
+    align-items: center;
+    display: flex;
+    gap: 8px;
+    white-space: nowrap;
+}
+
+#supplementalNav .supplementalNav__item + .supplementalNav__item {
+    padding-left: var(--topnav-gap);
+}
+
+#supplementalNav .supplementalNav__item--messages {
+    gap: 6px;
+}
+
+#supplementalNav #newMail {
+    margin: 0;
+}
+
+#supplementalNav #newMail a {
+    align-items: center;
+    display: inline-flex;
+}
+
+#supplementalNav #newMail img {
+    display: block;
+}
+
+#supplementalNav #msgCounter {
+    margin-left: var(--space-1);
+}
+
+#supplementalNav .supplementalNav__version-label {
+    font-weight: 600;
+    letter-spacing: .02em;
+}
+
+#supplementalNav .supplementalNav__version-label--mismatch {
+    color: #ffff8a;
+}
+
+/* ============================================================================
+   6. Forms - Inputs, Selects, Textareas, Buttons
+   Used in: All form elements throughout the application
+   ============================================================================ */
+
+tbody, thead, tr {
+    margin: 0;
+    padding: 0;
+    border: 0;
+}
+
+form label {
+    cursor: pointer;
+}
+
+fieldset {
+    border: none;
+}
+
+input, select, textarea, option, optgroup, td {
+    font: inherit;
+    color: inherit;
+}
+
+textarea[readonly],
+textarea[readonly]:focus,
+input[type='text'][readonly],
+input[type='text'][readonly]:focus,
+.readonly {
+    background-color: #eee !important;
+    text-shadow: 1px 1px var(--color-surface) !important;
+    cursor: not-allowed;
+}
+
+optgroup {
+    font-style: normal;
+    font-weight: bold;
+    background-color: var(--gray-300);
+}
+
+optgroup option {
+    font-weight: normal;
+    background-color: var(--color-surface);
+}
+
+#ta, .tmplvars textarea {
+    font-family: Consolas, 'Courier New', 'Courier', monospace;
+}
+
+form select {
+    background: var(--color-surface);
+    border-color: #AAAAAA #DEDEDE #DEDEDE #AAAAAA;
+    border-style: solid;
+    border-width: 1px;
+    padding: var(--space-1);
+    margin: 0;
+    min-height: 17px;
+    vertical-align: baseline;
+    border-radius: var(--radius-sm);
+}
+
+form input[type=text] {
+    line-height: 1;
+}
+
+form input[type=text],
+form input[type=password],
+form textarea {
+    background: var(--color-surface);
+    border-color: var(--gray-500) #DDD #DDD var(--gray-500);
+    border-style: solid;
+    border-width: 1px;
+    padding: var(--space-1) 2px var(--space-1) var(--space-1);
+    margin: 0 2px 0 0;
+    min-height: 17px;
+    vertical-align: baseline;
+    border-radius: var(--radius-sm);
+    box-shadow: 0px 1px 3px #E8E8E8 inset;
+}
+
+.sectionBody input.inputBox[type=text],
+.sectionBody input.inputBox[type=password],
+.sectionBody select.inputBox {
+    width: 350px;
+}
+
+input[type="email"]:focus,
+input[type="password"]:focus,
+input[type="search"]:focus,
+input[type="text"]:focus,
+input[type="url"]:focus,
+textarea:focus,
+form select:focus {
+    outline: none;
+    background: var(--color-surface);
+    border: 1px solid green;
+}
+
+input:is([type="button"], [type="submit"]) {
+    border: 1px solid var(--color-neutral-button-border);
+    cursor: pointer;
+    line-height: normal;
+    margin: -1px 0 0 5px;
+    min-height: 27px;
+    padding: var(--space-1) 10px;
+    overflow: visible;
+    background-color: var(--color-neutral-button-start);
+    color: var(--color-text-primary);
+    border-radius: var(--radius-sm);
+    box-shadow: none;
+    text-shadow: none;
+}
+
+input.checkbox,
+input.radio,
+input.submit,
+input.button,
+input[type="checkbox"],
+input[type="radio"],
+input[type="submit"],
+input[type="button"] {
+    height: auto !important;
+    width: auto !important;
+    cursor: pointer;
+}
+
+input:is([type="button"], [type="submit"]):hover {
+    border-color: var(--color-neutral-button-border);
+    background-color: var(--color-neutral-button-hover-end);
+}
+
+input:is([type="button"], [type="submit"]):active {
+    border-color: var(--color-neutral-button-border);
+    background-color: var(--color-neutral-button-active-start);
+}
+
+select {
+    border: 0;
+    background: #fcfcfc;
+    cursor: pointer;
+}
+
+.form {
+    padding: 15px;
+    border: solid 1px var(--gray-300);
+}
+
+form input.hidden {
+    display: none !important;
+    position: absolute;
+}
+
+.form label,
+.form input,
+.form textarea {
+    display: block;
+    float: left;
+    vertical-align: middle;
+}
+
+.form label {
+    padding-right: var(--space-5);
+    text-align: right;
+    width: 110px;
+}
+
+form textarea {
+    height: 78px;
+    width: 350px;
+    line-height: 1.5;
+    overflow: auto;
+}
+
+.form legend {
+    color: #04C;
+    font-weight: bold;
+    padding: 5px;
+}
+
+.form select {
+    display: inline;
+    float: left;
+}
+
+.form br {
+    clear: both;
+}
+
+input.submit {
+    display: block !important;
+    float: none !important;
+    margin: var(--space-5) 0 0 140px !important;
+}
+
+.form fieldset.list {
+    margin: 6px 6px 3px 0;
+}
+
+.form fieldset.list legend {
+    display: none;
+}
+
+.form fieldset.list label,
+.form fieldset.list input {
+    padding: 0;
+    margin: 0 0 3px;
+    float: left;
+    display: inline;
+    border: 0;
+    background: none;
+    width: auto;
+    height: auto;
+}
+
+.form fieldset.list label {
+    padding-left: 5px;
+    text-align: left;
+    width: auto;
+}
+
+form .imeoff {
+    ime-mode: disabled;
+}
+
+/* ============================================================================
+   7. Layout Components - Sections, Headers, Bodies
+   Used in: Content areas, settings pages, form sections
+   ============================================================================ */
+
+.sectionBody fieldset {
+    padding: 15px;
+}
+
+.sectionBody legend {
+    font-weight: bold;
+    padding: 5px 15px;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border-default);
+    box-shadow: var(--shadow-md);
+    border-radius: var(--radius-sm);
+}
+
+.sectionBody h3 {
+    font-size: 1.1em;
+    font-weight: bold;
+    padding-bottom: 0;
+    margin-bottom: 10px;
+}
+
+.sectionHeader {
+    color: var(--color-section-header-text);
+    margin: 0 var(--space-2);
+    padding: var(--space-2) var(--space-4);
+    font-weight: bold;
+    border: 1px solid var(--color-section-header-end);
+    border-bottom: none;
+    background-color: var(--color-section-header-end);
+    box-shadow: 0 1px 0 var(--color-surface) inset;
+    border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+}
+
+.tab-page .sectionHeader {
+    margin: 2px 3px 0;
+}
+
+.sectionBody {
+    position: relative;
+    margin: var(--space-2);
+    display: block;
+}
+
+.tab-page .sectionBody,
+.section .sectionBody {
+    background: var(--color-section-bg);
+    border: 1px solid var(--gray-400);
+    margin: 0 3px 15px;
+    padding: 15px;
+}
+
+.section .sectionBody {
+    margin: 0 var(--space-2) var(--space-2);
+    background-color: var(--color-surface);
+}
+
+.comment {
+    color: var(--gray-500);
+}
+
+thead {
+    color: var(--gray-900);
+    height: 18px !important;
+    background-color: var(--gray-200);
+}
+
+thead td {
+    color: var(--gray-900);
+    border-top: 1px solid var(--color-surface);
+}
+
+li {
+    padding: 0;
+    margin: 0;
+    list-style: disc;
+}
+
+li::marker {
+    color: var(--gray-500);
+}
+
+ul {
+    margin: 0 var(--space-5) 0 var(--space-5);
+}
+
+.screen {
+    border: 1px solid var(--gray-300);
+    text-align: center;
+}
+
+a img {
+    border: 0;
+}
+
+.even {
+    background: #D9E7C2;
+}
+
+.odd {
+    background: var(--color-surface);
+}
+
+/* -------------------------[ end sortable table ]--- */
+.disabledImage {
+    width: 20px;
+    opacity: 0.3;
+}
+
+.disabledImage img {
+    border: 0;
+}
+
+.editorCell {
+    border-top: 1px solid #808080;
+    text-align: left;
+    vertical-align: baseline;
+}
+
+.row1, .row2, .row3 {
+    color: var(--color-text-primary);
+}
+
+.row1 {
+    background-color: var(--color-surface);
+}
+
+.row2 {
+    background-color: #C8DAA2;
+}
+
+.row3 {
+    background-color: var(--gray-100);
+}
+
+/* ============================================================================
+   8. Tree Components - Site Tree, Context Menu
+   Used in: Left frame site tree, document tree navigation
+   ============================================================================ */
+
+div.treeframebody {
+    background: var(--gray-100) !important;
+    background-image: linear-gradient(180deg,
+        rgba(13, 44, 68, 0.03) 0%,
+        rgba(10, 34, 51, 0.05) 100%) !important;
+    box-shadow: var(--shadow-inset);
+    padding: var(--space-2);
+}
+
+#treeMenu * {
+    vertical-align: middle;
+}
+
+#treeHolder {
+    cursor: default;
+    height: 100%;
+    padding: 6px 8px 0;
+    line-height: 1.3em;
+    font-family: Arial, "Helvetica Neue", Helvetica, Meiryo, "Hiragino Kaku Gothic Pro", sans-serif;
+}
+
+#treeHolder {
+    padding-left: 12px;
+}
+
+#treeRoot {
+    margin-left: -10px;
+}
+
+#treeRoot div img {
+    margin: 0 0 0 -6px;
+    vertical-align: middle;
+}
+
+#floater {
+    display: none;
+    position: absolute;
+    width: 200px;
+    padding: 5px;
+    top: 25px;
+    left: 4px;
+    background: var(--color-surface);
+    border: 1px solid var(--gray-400);
+    z-index: 500;
+}
+
+.rootNode, .treeNode, .treeNodeHover, .treeNodeSelected, .emptyNode {
+    color: #000;
+    cursor: pointer;
+    width: auto;
+    margin-right: 0;
+}
+
+div.treeNode {
+    white-space: nowrap;
+}
+
+.treeNodeSelected,
+.treeNodeHover {
+    background-color: var(--color-surface);
+    border: 1px solid var(--gray-400);
+    color: #000;
+    padding: 1px 2px;
+    margin-left: -3px;
+}
+
+.unpublished a, .unpublishedNode {
+    color: #B68282;
+}
+
+.deletedNode {
+    color: #A52A2A;
+    text-decoration: line-through;
+}
+
+.publishedNode {
+    color: var(--color-text-dark);
+}
+
+.emptyNode {
+    color: #aaa;
+    cursor: default;
+}
+
+.notInMenuNode {
+    color: var(--gray-700);
+    text-decoration: none;
+}
+
+.protectedNode {
+    color: #77d;
+}
+
+#treeSplitter {
+    width: 10px;
+    height: 100%;
+    position: absolute;
+    right: -10px;
+}
+
+.disabledPlugin a {
+    color: #aaa;
+    text-decoration: line-through;
+}
+
+/* ============================================================================
+   9. Tables & Grids - Data Tables, Sortable Tables
+   Used in: User lists, resource grids, sortable data tables
+   ============================================================================ */
+
+.grid {
+    width: 100%;
+    background-color: var(--color-surface);
+    border: 1px solid silver;
+    border-collapse: collapse;
+}
+
+.grid th, .grid td {
+    padding: var(--space-2);
+}
+
+.gridHeader, .grid th {
+    color: var(--gray-900);
+    font-weight: bold;
+    white-space: nowrap;
+    background-color: #d2d2d2;
+    text-align: left;
+}
+
+.gridItem {
+    background-color: var(--color-surface);
+    padding: 3px;
+}
+
+.gridAltItem {
+    background-color: #eeeeee;
+    padding: 3px;
+}
+
+.gridRowIcon:hover {
+    background-color: #f5f5dc;
+}
+
+.grid a {
+    text-decoration: none;
+}
+
+.grid img {
+    vertical-align: middle;
+    padding-right: 4px;
+}
+
+/* -------------------------[ search bar ]--- */
+.searchbar {
+    width: 100%;
+    border: 1px solid silver;
+    background-color: #DBDBDB;
+}
+
+.searchtext {
+    height: 18px;
+    padding: 2px;
+}
+
+/* -------------------------[ home page main links ]--- */
+a.hometblink, a.hometblink:active, a.hometblink:visited, a.hometblink:link, .hometblink {
+    text-decoration: underline;
+    color: var(--gray-900);
+    font-weight: bold;
+}
+
+a.hometblink:hover {
+    text-decoration: underline;
+    color: Gray;
+}
+
+#preLoader {
+    position: absolute;
+    z-index: 50000;
+    width: 100%;
+    height: 100%;
+    text-align: center;
+    vertical-align: middle;
+    background-color: rgba(255, 255, 255, .3);
+}
+
+.preLoaderText {
+    background-color: var(--color-surface);
+    border-radius: var(--radius-xl);
+    opacity: .7;
+    width: 300px;
+    height: 150px;
+    margin: 70px auto;
+    padding: 50px;
+    border: 1px solid var(--gray-500);
+}
+
+/* -------------------------[ contextmenu in editing modules ]--- */
+.contextMenu {
+    background: var(--color-surface);
+    margin: 0;
+    padding: 0;
+    border: 1px solid #039;
+    border-color: #eaeaea #909090 #707070 #eaeaea;
+    position: absolute;
+    z-index: 10000;
+}
+
+.cntxMnuItem {
+    background-image: none;
+    cursor: pointer;
+    color: var(--color-text-primary);
+    padding: 3px 16px 3px 2px;
+}
+
+.cntxMnuItemDisabled {
+    cursor: default;
+    padding: 3px 16px 3px 2px;
+    color: var(--color-text-darker);
+}
+
+.cntxMnuItemOver {
+    cursor: pointer;
+    color: var(--color-text-primary);
+    background: #e8f1fa;
+    padding: 2px 15px 2px 1px;
+    border: 1px solid #c5d5e4;
+}
+
+.cntxMnuItem img, .cntxMnuItemOver img, .cntxMnuItemDisabled img {
+    margin: 0 var(--space-2) 0 0;
+}
+
+.cntxMnuItem img, .cntxMnuItemDisabled img {
+    opacity: .3;
+}
+
+.cntxMnuSeparator {
+    font-size: 0;
+    height: 1px;
+    background-color: silver;
+    overflow: hidden;
+    margin: 3px 1px 3px 28px;
+}
+
+/* ============================================================================
+   10. Navigation - Top Menu, Supplemental Nav
+   Used in: Main top navigation bar, sub-navigation menus
+   ============================================================================ */
+
+/* -------------------------[ Top Navbar of snap in top menu bar layout ]--- */
+#topMenu {
+    --topnav-item-height: 32px;
+    --topnav-gap: 4px;
+    --subnav-height: 32px;
+    --subnav-horizontal-padding: 16px;
+    --topnav-padding-top: 14px;
+    --topnav-background: #0f3356;
+    --topnav-border: #0f4f7b;
+    --topnav-link-color: #e9f6ff;
+    --topnav-link-hover-color: #ffffff;
+    --topnav-link-hover-bg: #1671a5;
+    --topnav-link-active-bg: #0f446c;
+    background-color: var(--topnav-background);
+    border-bottom: 1px solid var(--topnav-border);
+}
+#topMenu {
+    background: linear-gradient(180deg, #11416b 0%, #0c2f4d 100%);
+}
+#Navcontainer {
+    color: #e9f7ff;
+    padding: var(--topnav-padding-top, 10px) var(--subnav-horizontal-padding) calc(var(--subnav-height) + 12px);
+    position: relative;
+    text-shadow: none;
+}
+
+#nav {
+    display: flex;
+    align-items: flex-end;
+    justify-content: flex-start;
+    column-gap: var(--topnav-gap);
+    row-gap: var(--space-2);
+    flex-wrap: wrap;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+#nav > li {
+    list-style: none;
+}
+
+#nav > li > a {
+    border: 1px solid transparent;
+    border-radius: 6px 6px 0 0;
+    color: var(--topnav-link-color);
+    display: block;
+    line-height: var(--topnav-item-height);
+    padding: 0 var(--space-5);
+    text-decoration: none;
+    white-space: nowrap;
+    background: transparent;
+    transition: color var(--transition-normal), background-color var(--transition-normal), border-color var(--transition-normal);
+}
+
+#nav > li > a:hover,
+#nav > li > a:active,
+#nav > li > a:focus-visible {
+    color: var(--topnav-link-hover-color);
+    background: var(--topnav-link-hover-bg);
+    border-color: var(--topnav-border);
+}
+
+#nav > li.active > a {
+    background: var(--topnav-link-active-bg);
+    border-color: var(--topnav-link-active-bg);
+    border-top: 1px solid var(--topnav-border);
+    border-bottom: none;
+    color: var(--topnav-link-hover-color);
+    position: relative;
+    text-shadow: none;
+    z-index: 2;
+}
+
+#nav > li > ul.subnav {
+    display: none;
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: calc(var(--topnav-item-height) + 15px);
+    margin: 0;
+    list-style: none;
+    padding: 6px var(--subnav-horizontal-padding);
+    min-height: var(--subnav-height);
+    align-items: center;
+    flex-wrap: wrap;
+    column-gap: var(--topnav-gap);
+    row-gap: 6px;
+    border-top: 1px solid var(--topnav-border);
+    border-bottom: 1px solid var(--topnav-border);
+    background: var(--topnav-link-active-bg);
+    z-index: 1;
+    box-shadow: none;
+}
+
+#nav > li.active > ul.subnav {
+    display: flex;
+}
+
+#nav > li > ul.subnav > li {
+    margin: 0;
+    list-style: none;
+}
+
+#nav > li > ul.subnav a {
+    color: #f1fbfc;
+    cursor: pointer;
+    display: block;
+    font-weight: normal;
+    line-height: var(--subnav-height);
+    padding: 0 18px;
+    text-decoration: none;
+    border-radius: var(--radius-lg);
+    transition: background-color var(--transition-normal), color var(--transition-normal);
+}
+
+#nav > li > ul.subnav a:hover,
+#nav > li > ul.subnav a:focus-visible {
+    background: #184753;
+    color: #ffffff;
+    text-shadow: none;
+}
+
+#nav > li > ul.subnav a:active {
+    color: #d9edf1;
+}
+
+/* -------------------------[ Contextual Menu used in the Tree Menu ]--- */
+#mx_contextmenu {
+    position: absolute;
+    height: auto;
+    visibility: hidden;
+    z-index: 10000;
+    width: 165px;
+    background-color: var(--color-surface);
+    margin: 0;
+    padding-bottom: 10px;
+    border: 1px solid var(--color-border-light);
+    border-right-color: #dcdcdc;
+    border-bottom-color: #dcdcdc;
+    overflow: hidden;
+    line-height: 11px;
+    box-shadow: var(--shadow-lg);
+}
+
+#mx_contextmenu .menuLink {
+    cursor: pointer;
+    color: var(--color-text-dark);
+    padding: 3px 5px 3px 4px;
+}
+
+#mx_contextmenu .menuLink:hover {
+    background: #e6f1fb;
+    border: 1px solid #fdfdfd;
+    border-bottom-color: #d5e4f2;
+    color: var(--color-text-primary);
+}
+
+#mx_contextmenu .menuLink:hover,
+#mx_contextmenu .menuLinkDisabled {
+    cursor: pointer;
+    padding: 2px 4px 2px 3px;
+}
+
+#mx_contextmenu .menuLinkDisabled {
+    cursor: default;
+    color: #787878;
+}
+
+#mx_contextmenu .menuLink img,
+#mx_contextmenu .menuLink:hover img,
+#mx_contextmenu .menuLinkDisabled img {
+    margin-right: 5px;
+}
+
+#mx_contextmenu .menuLink img,
+#mx_contextmenu .menuLinkDisabled img {
+    opacity: .3;
+}
+
+#mx_contextmenu .menuLink:hover img {
+    opacity: 1;
+}
+
+#mx_contextmenu #nameHolder {
+    color: var(--color-surface);
+    text-align: left;
+    cursor: default;
+    font-weight: bold;
+    padding: 6px 4px;
+    margin-bottom: 3px;
+    text-shadow: 0px -1px 0px var(--color-text-dark);
+    background-image: linear-gradient(var(--color-primary-start), var(--color-primary-end));
+}
+
+#mx_contextmenu .seperator {
+    font-size: 0;
+    height: 1px;
+    background-color: silver;
+    overflow: hidden;
+    margin: 3px 1px 3px 28px;
+}
+
+
+/* -------------------------[ Settings Table ]--- */
+.settings {
+    width: 600px;
+}
+
+.settings tr {
+    width: 100% !important;
+}
+
+.settings th {
+    width: 200px !important;
+    text-align: left;
+    color: #555;
+    font-size: 1.2em;
+}
+
+.filelist td {
+    border-bottom: 1px solid #C2C3CF;
+}
+
+/* ============================================================================
+   11. Tabs System - Dynamic Tab Pane Control
+   Used in: Document editor, settings pages, multi-tab interfaces
+   ============================================================================ */
+
+.dynamic-tab-pane-control.tab-pane {
+    position: relative;
+    width: 100%;
+}
+
+.dynamic-tab-pane-control .tab-row .tab {
+    color: var(--color-secondary-text);
+    font-size: 1em;
+    cursor: pointer;
+    display: inline;
+    margin: 3px 2px 1px 0;
+    float: left;
+    padding: var(--space-2) var(--space-4);
+    z-index: 1;
+    position: relative;
+    top: 1px;
+    border: 1px solid var(--color-secondary-border);
+    border-radius: var(--radius-md) var(--radius-md) 0 0;
+    background-color: var(--color-secondary-start);
+}
+
+.dynamic-tab-pane-control .tab-row .tab.hover {
+    text-decoration: none;
+    color: var(--color-secondary-hover-text);
+    border-color: var(--color-secondary-border);
+    background-color: var(--color-secondary-hover-start);
+    background-image: linear-gradient(var(--color-secondary-hover-start), var(--color-secondary-hover-end));
+}
+
+.dynamic-tab-pane-control .tab-row .tab.selected {
+    color: var(--gray-900);
+    z-index: 999;
+    top: 1px;
+    border-width: 1px;
+    border-bottom-style: solid;
+    border-color: var(--color-primary-hover-end) #b7c2c7 var(--color-surface) #b7c2c7;
+    border-radius: var(--radius-md) var(--radius-md) 0 0;
+    border-width: 1px 1px 0;
+    background-color: var(--color-surface);
+    background-image: none;
+}
+
+.dynamic-tab-pane-control .tab-row .tab.selected span {
+    color: var(--color-text-darker);
+    background-color: var(--color-surface);
+    text-shadow: none;
+}
+
+.dynamic-tab-pane-control .tab-row .tab span {
+    color: inherit;
+    text-decoration: none;
+}
+
+.dynamic-tab-pane-control .tab-row .tab.hover span {
+    color: var(--color-secondary-hover-text);
+}
+
+.dynamic-tab-pane-control .tab-row .tab.selected.hover {
+    color: var(--gray-900);
+    border-color: var(--color-primary-hover-end) #b7c2c7 var(--color-surface) #b7c2c7;
+    background-color: var(--color-surface);
+    background-image: none;
+}
+
+.dynamic-tab-pane-control .tab-row .tab.selected.hover span {
+    color: var(--color-text-darker);
+}
+
+.dynamic-tab-pane-control .tab-row .tab .alert {
+    color: #c00;
+}
+
+.dynamic-tab-pane-control .tab-row .tab.selected .alert {
+    color: #c00;
+}
+
+.dynamic-tab-pane-control .tab-page {
+    clear: both;
+    background: var(--color-surface);
+    z-index: 2;
+    position: relative;
+    top: -2px;
+    padding: var(--space-5) 15px 14px !important;
+}
+
+.dynamic-tab-pane-control .tab-row {
+    z-index: 1;
+    white-space: nowrap;
+}
+
+.dynamic-tab-pane-control ul {
+    padding-left: 10px;
+    padding-right: 10px;
+    padding-bottom: 5px;
+}
+
+.dynamic-tab-pane-control li {
+    padding-left: 5px;
+    padding-right: 5px;
+}
+
+/* -------------------------[ Tree buttons ]--- */
+.treeButton {
+    display: block;
+    cursor: pointer;
+    color: var(--color-text-primary);
+    border: 1px;
+    border-bottom-color: #809c47;
+    padding: 3px 5px;
+    white-space: nowrap;
+    vertical-align: middle;
+}
+
+.treeButton:hover {
+    border: 1px solid #88939E;
+    padding: 2px var(--space-1);
+    background: var(--color-surface);
+}
+
+.treeButtonDisabled {
+    cursor: default;
+    border: 1px solid #657587;
+    padding: 2px var(--space-1);
+    color: var(--gray-700);
+    border-width: 0;
+    opacity: .5;
+}
+
+/* -------------------------[ Welcome Page ]--- */
+a.hometblink, a.hometblink img {
+    border: 0 !important;
+    text-decoration: none !important;
+}
+
+.wm_button {
+    float: left;
+    margin: 0 var(--space-3) 2px 0;
+    text-align: center;
+}
+
+/* -------------------------[ Welcome Page ]--- */
+#mainActionPages {
+    background: var(--gray-100);
+    background-image: linear-gradient(180deg,
+        rgba(255, 255, 255, 0.8) 0%,
+        rgba(245, 245, 245, 0.95) 100%);
+}
+
+.tab-page {
+    border: 1px solid #AAA;
+    border-radius: 0 0 var(--radius-md) var(--radius-md);
+}
+
+.sectionBody .tab-page {
+    padding: 15px 15px 20px !important;
+}
+
+/* -------------------------[ New sortable table class ]--- */
+table.sortabletable {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.sortabletable tr.even {
+    background: #E9F0F3;
+}
+
+.sortabletable td, .sortabletable th {
+    padding: var(--space-2);
+    border: 1px solid var(--gray-400);
+}
+
+.sortabletable th {
+    text-align: left;
+    cursor: pointer;
+    color: var(--gray-900);
+}
+
+.sortabletable th a {
+    text-decoration: none;
+    color: var(--gray-900);
+}
+
+.sortabletable th:active {
+    background: var(--gray-400);
+    padding: 3px var(--space-1) 1px 6px;
+}
+
+/* -------------------------[ Pagination table ]--- */
+#max-display-records {
+    margin: 10px 0;
+}
+
+#pagination {
+    margin: 10px 0;
+}
+
+#pagination ul {
+    margin: 10px 0;
+    display: inline;
+}
+
+#pagination li {
+    list-style: none;
+    display: inline;
+    width: 15px;
+    margin: 0 0 0 1px;
+    padding: 0;
+}
+
+#pagination li a,
+#pagination li span {
+    padding: 3px var(--space-2);
+    border: 1px solid #D9E7C2;
+    text-decoration: none;
+    color: var(--gray-900);
+}
+
+#pagination li span {
+    color: #D9E7C2;
+    cursor: default;
+}
+
+#pagination li.currentPage a, #pagination li a:hover {
+    color: var(--color-surface);
+    background-color: #7fa53d;
+    border: 1px solid #567959;
+}
+
+fieldset.tab-page {
+    border: 1px solid var(--gray-200) !important;
+}
+
+h2#edit_document_title {
+    font-size: 15px;
+    color: var(--gray-100);
+    width: 100%;
+    border-bottom: none;
+    padding: 5px 10px;
+}
+
+/* ============================================================================
+   12. Action Buttons - Fixed Position Controls
+   Used in: Document editor, form pages, action toolbars
+   From: https://github.com/manse/ScienceStyle
+   ============================================================================ */
+
+#actions {
+    background: none repeat scroll 0 0 rgba(60, 60, 60, 0.2);
+    margin: 0;
+    padding: var(--space-2) var(--space-4) !important;
+    position: fixed;
+    right: var(--space-4);
+    text-align: right;
+    top: var(--space-2);
+    z-index: 100;
+    border-radius: var(--radius-lg);
+}
+
+select#stay {
+    padding: var(--space-2);
+}
+
+.actionButtons {
+    margin-bottom: 15px;
+}
+
+.actionButtons:after {
+    content: "";
+    display: block;
+    clear: both;
+}
+
+ul.actionButtons {
+    margin: 0;
+    padding: 0;
+    /* accommodate border on buttons - */
+    background: none;
+    width: auto;
+    white-space: nowrap;
+    padding-bottom: 10px;
+}
+
+#actions .actionButtons {
+    padding-bottom: 0;
+}
+
+.actionButtons li {
+    list-style: none;
+    margin-right: 6px;
+    padding: 0;
+    float: left;
+}
+
+.actionButtons img {
+    vertical-align: top;
+    margin-top: 1px;
+    opacity: .7;
+}
+
+.actionButtons a:hover img {
+    opacity: 1;
+}
+
+.actionButtons a {
+    display: block;
+    float: left;
+    border-radius: var(--radius-sm);
+    color: var(--color-warning);
+    font-size: 1em;
+    font-weight: 700;
+    outline: medium none;
+    padding: var(--space-2) var(--space-3);
+    text-decoration: none;
+    white-space: nowrap;
+    background-color: var(--color-neutral-button-start);
+}
+
+.actionButtons a img {
+    display: none;
+}
+
+.actionButtons a:hover {
+    border-color: var(--color-neutral-button-border);
+    background-color: var(--color-neutral-button-hover-end);
+}
+
+.actionButtons a:active {
+    border-color: var(--color-neutral-button-border);
+    background-color: var(--color-neutral-button-active-start);
+}
+
+.actionButtons a.disabled {
+    border: 1px solid var(--color-border-default);
+    padding: 2px var(--space-1);
+    color: var(--gray-700);
+    background-color: var(--color-surface);
+    cursor: default;
+    pointer-events: none;
+}
+
+.actionButtons .opendraft a {
+    background-color: var(--color-draft-start);
+    border-color: var(--color-draft-end);
+}
+
+.actionButtons select, .actionButtons span.and {
+    display: block;
+    float: left;
+}
+
+.actionButtons span.and {
+    padding: 4px 2px;
+}
+
+.actionButtons a.disabled img {
+    opacity: .3;
+}
+
+.actionButtons .and {
+    margin: 0 2px 0 5px;
+    color: #3b454f;
+    font-weight: 700;
+}
+
+.actionButtons #Button1 a,
+.actionButtons li.primary a,
+.actionButtons a.primary,
+.actionButtons a.default {
+    color: var(--color-surface);
+    box-shadow: none;
+    text-shadow: none;
+    background-color: var(--color-primary);
+    border-color: var(--color-primary-end);
+}
+
+.actionButtons #Button1 a:hover,
+.actionButtons a:hover.default {
+    background-color: var(--color-primary-hover-start);
+    border-color: var(--color-primary-hover-end);
+}
+
+.actionButtons #Button1 a:active,
+.actionButtons a:active.default {
+    background-color: var(--color-primary-active-start);
+    border-color: var(--color-primary-active-end);
+}
+
+
+#loadingmask {
+    display: none;
+}
+
+/* ============================================================================
+   13. Specialized Forms - Mutate Forms, Date Pickers
+   Used in: Document editor forms, settings forms with date pickers
+   ============================================================================ */
+
+form#mutate dt,
+form#mutate dd {
+    margin-bottom: 10px;
+}
+
+form#mutate dt label,
+form#mutate dt h3.label {
+    font-size: 1em;
+    display: inline;
+    float: left;
+    width: 200px;
+    color: #821517 !important;
+    font-weight: bold;
+}
+
+form#mutate dd {
+    margin-left: 210px;
+}
+
+form#mutate input.disabled {
+    background-color: var(--gray-100) !important;
+}
+
+form#mutate select.inputBox,
+form#mutate input,
+form#mutate textarea {
+    width: 300px;
+}
+
+form#mutate textarea.textarea {
+    width: 90%;
+    height: 200px;
+}
+
+#tv_body input[type=text],
+#tv_body textarea {
+    background: var(--color-surface);
+}
+
+form#mutate textarea.tv_textareamini {
+    height: 100px;
+    width: 300px;
+    overflow-y: scroll;
+}
+
+form#mutate textarea.tv_textarea {
+    height: 100px;
+    width: 100%;
+    overflow-y: scroll;
+}
+
+/*
+* Styling for datepicker elements in settings and templavars
+*/
+form#mutate input.date,
+form#mutate input.tvdate {
+    margin-right: 10px;
+}
+
+/*
+* Individual Styles for fieldset#settings_page_settings
+*/
+form#mutate fieldset#settings_page_settings input#pub_date,
+form#mutate fieldset#settings_page_settings input#unpub_date {
+    width: 150px;
+}
+
+form#mutate fieldset#settings_page_settings select {
+    width: 155px;
+}
+
+/*
+* Individual Styles for fieldset#meta_keywords
+*/
+form#mutate fieldset#meta_keywords select.inputBox {
+    display: block;
+    margin-bottom: 0;
+}
+
+form#mutate fieldset#meta_keywords dl.keywords {
+    float: left;
+    margin-right: 30px;
+}
+
+form#mutate fieldset#meta_keywords dl.metatags {
+    float: left;
+}
+
+form#mutate fieldset#meta_keywords dl dt label {
+    width: 100px;
+}
+
+form#mutate fieldset#meta_keywords dl dd {
+    margin-left: 110px;
+}
+
+/*
+* Individual Styles for fieldset#document_content
+*/
+
+fieldset#document_content textarea#ta {
+    width: 100%;
+    height: 400px;
+    font-size: 1em;
+}
+
+/*
+* Individual Styles for fieldset#access_permissions
+*/
+fieldset#access_permissions dt label {
+    width: 200px;
+}
+
+fieldset#access_permissions dd {
+    margin-left: 210px;
+}
+
+fieldset#access_permissions dl dd ul li {
+    list-style-type: none;
+}
+
+/* -------------------------[ date picker ]--- */
+input.DatePicker, #mutate input.DatePicker, #userPane input.DatePicker, #webUserPane input.DatePicker, input#datefrom.DatePicker, input#dateto.DatePicker {
+    width: 150px;
+    padding: 3px 3px 3px 24px;
+    background-color: var(--color-surface);
+    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><rect x="2" y="3" width="12" height="11" fill="none" stroke="%23999" stroke-width="1"/><line x1="5" y1="1" x2="5" y2="5" stroke="%23999" stroke-width="1"/><line x1="11" y1="1" x2="11" y2="5" stroke="%23999" stroke-width="1"/></svg>');
+    background-repeat: no-repeat;
+    background-position: var(--space-1) center;
+}
+
+input:focus.DatePicker, #mutate input:focus.DatePicker, #userPane input:focus.DatePicker, #webUserPane input:focus.DatePicker, input#datefrom:focus.DatePicker, input#dateto:focus.DatePicker {
+    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><rect x="2" y="3" width="12" height="11" fill="none" stroke="%230066cc" stroke-width="1.5"/><line x1="5" y1="1" x2="5" y2="5" stroke="%230066cc" stroke-width="1.5"/><line x1="11" y1="1" x2="11" y2="5" stroke="%230066cc" stroke-width="1.5"/></svg>');
+    cursor: text;
+}
+
+.phptextarea {
+    font-family: Consolas, 'Courier New', 'Courier', monospace;
+    box-sizing: border-box;
+}
+
+/* Custom */
+/* replace warning red color in tabs */
+strong[style*='color:#EF1D1D'] {
+    color: yellow !important;
+}
+
+.selected strong[style*='color:#EF1D1D'] {
+    color: red !important;
+}
+
+.tmplvars tr {
+    height: 24px;
+}
+
+.tvname {
+    width: 150px;
+    white-space: nowrap;
+}
+
+.okmsg {
+    background-color: var(--color-success-bg);
+    border: 2px solid var(--color-success-light);
+    padding: var(--space-2);
+    margin-bottom: var(--space-2);
+}
+
+/* ============================================================================
+   14. Custom Navigation Gradients - Aurora Theme
+   Used in: Top menu bar, navigation system
+   Note: Complex gradient system for visual polish
+   ============================================================================ */
+
+/* #topMenuの背景 - 左側抑えめ、右側グラデーション */
+#topMenu {
+    background-color: #0f1825 !important;
+    background-image:
+        /* === 光源：左側は控えめ、右側は色の変化 === */
+
+        /* 左側 - ティール（青緑）系 - かなり控えめ */
+        radial-gradient(ellipse 900px 80px at 15% 50%, rgba(20, 184, 166, 0.12) 0%, rgba(20, 184, 166, 0.07) 22%, rgba(20, 184, 166, 0.03) 42%, transparent 65%),
+
+        radial-gradient(circle 110px at 12% 58%, rgba(6, 182, 212, 0.10) 0%, rgba(6, 182, 212, 0.05) 28%, rgba(6, 182, 212, 0.02) 55%, transparent 78%),
+
+        /* 左寄り - シアン・青系 - 控えめ */
+        radial-gradient(ellipse 800px 75px at 28% 50%, rgba(14, 165, 233, 0.11) 0%, rgba(14, 165, 233, 0.06) 24%, rgba(14, 165, 233, 0.03) 45%, transparent 68%),
+
+        radial-gradient(circle 95px at 25% 42%, rgba(59, 130, 246, 0.09) 0%, rgba(59, 130, 246, 0.05) 30%, rgba(59, 130, 246, 0.02) 58%, transparent 82%),
+
+        /* 中央 - 紫系へ移行 - やや抑えめ */
+        radial-gradient(ellipse 850px 70px at 50% 50%, rgba(139, 92, 246, 0.16) 0%, rgba(139, 92, 246, 0.09) 26%, rgba(139, 92, 246, 0.04) 48%, transparent 70%),
+
+        radial-gradient(circle 100px at 48% 65%, rgba(168, 85, 247, 0.14) 0%, rgba(168, 85, 247, 0.07) 32%, rgba(168, 85, 247, 0.03) 60%, transparent 84%),
+
+        /* 中央やや右 - ローズ・オレンジ系へ - 通常 */
+        radial-gradient(ellipse 900px 75px at 68% 50%, rgba(251, 146, 60, 0.22) 0%, rgba(251, 146, 60, 0.12) 24%, rgba(251, 146, 60, 0.06) 46%, transparent 68%),
+
+        radial-gradient(circle 105px at 65% 55%, rgba(251, 113, 133, 0.19) 0%, rgba(251, 113, 133, 0.10) 30%, rgba(251, 113, 133, 0.05) 56%, transparent 80%),
+
+        /* 右側 - アンバー・黄金系 - 通常 */
+        radial-gradient(ellipse 1000px 85px at 85% 50%, rgba(245, 158, 11, 0.25) 0%, rgba(245, 158, 11, 0.15) 22%, rgba(245, 158, 11, 0.07) 40%, transparent 62%),
+
+        radial-gradient(circle 115px at 82% 48%, rgba(251, 191, 36, 0.22) 0%, rgba(251, 191, 36, 0.12) 28%, rgba(251, 191, 36, 0.05) 54%, transparent 76%),
+
+        /* 右端 - 茶色系 - 通常 */
+        radial-gradient(circle 90px at 92% 60%, rgba(217, 119, 6, 0.20) 0%, rgba(217, 119, 6, 0.10) 32%, rgba(217, 119, 6, 0.04) 60%, transparent 85%),
+
+        /* === 全体を繋ぐ横方向グラデーション === */
+        linear-gradient(90deg,
+            rgba(20, 184, 166, 0.05) 0%,
+            rgba(14, 165, 233, 0.04) 15%,
+            rgba(59, 130, 246, 0.03) 25%,
+            rgba(139, 92, 246, 0.05) 40%,
+            rgba(168, 85, 247, 0.06) 50%,
+            rgba(251, 146, 60, 0.07) 65%,
+            rgba(245, 158, 11, 0.09) 80%,
+            rgba(217, 119, 6, 0.07) 100%
+        ),
+
+        /* ベースの縦方向グラデーション */
+        linear-gradient(180deg,
+            rgba(30, 64, 175, 0.08) 0%,
+            rgba(20, 24, 38, 0.95) 50%,
+            rgba(15, 23, 24, 1) 100%
+        ) !important;
+    border-bottom: 1px solid rgba(59, 130, 246, 0.20) !important;
+    backdrop-filter: blur(20px) saturate(180%);
+    -webkit-backdrop-filter: blur(20px) saturate(180%);
+}
+
+/* === メインナビゲーション項目 === */
+#nav > li > a {
+    background: transparent !important;
+    color: rgba(226, 232, 240, 0.55) !important;
+    border-color: transparent !important;
+    transition: all var(--transition-normal) !important;
+}
+
+#nav > li > a:hover,
+#nav > li > a:active,
+#nav > li > a:focus-visible {
+    background: rgba(59, 130, 246, 0.2) !important;
+    border-color: rgba(59, 130, 246, 0.3) !important;
+    color: rgba(255, 255, 255, 1) !important;
+}
+
+#nav > li.active > a {
+    background: rgba(15, 23, 42, 0.6) !important;
+    backdrop-filter: blur(10px) !important;
+    -webkit-backdrop-filter: blur(10px) !important;
+    border-color: rgba(59, 130, 246, 0.2) !important;
+    color: rgba(255, 255, 255, 1) !important;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2) !important;
+}
+
+/* === サブナビゲーション === */
+#nav > li > ul.subnav {
+    background: rgba(15, 23, 42, 0.6) !important;
+    backdrop-filter: blur(20px) saturate(160%) !important;
+    -webkit-backdrop-filter: blur(20px) saturate(160%) !important;
+    border-top-color: rgba(59, 130, 246, 0.2) !important;
+    border-bottom-color: rgba(59, 130, 246, 0.2) !important;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3) !important;
+}
+
+#nav > li > ul.subnav a {
+    color: rgba(226, 232, 240, 0.95) !important;
+    background: transparent !important;
+    transition: all var(--transition-normal) !important;
+}
+
+#nav > li > ul.subnav a:hover,
+#nav > li > ul.subnav a:focus-visible {
+    background: rgba(59, 130, 246, 0.25) !important;
+    color: rgba(255, 255, 255, 1) !important;
+}
+
+/* === 右上のユーザー情報エリア === */
+#supplementalNav {
+    background: linear-gradient(180deg, rgba(15, 23, 24, 0.4), rgba(16, 35, 37, 0.4)) !important;
+    backdrop-filter: blur(15px);
+    -webkit-backdrop-filter: blur(15px);
+    border: 1px solid rgba(59, 130, 246, 0.15);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+}
+
+#supplementalNav a {
+    color: rgba(225, 241, 244, 0.9) !important;
+}
+
+#supplementalNav a:hover,
+#supplementalNav a:focus-visible {
+    color: rgba(255, 255, 255, 1) !important;
+}

--- a/manager/media/style/LytmusBlue/style.php
+++ b/manager/media/style/LytmusBlue/style.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * Filename:       media/style/$modx->config['manager_theme']/style.php
+ * Function:       Manager style variables for images and icons.
+ * Encoding:       UTF-8
+ * Credit:         icons by Mark James of FamFamFam http://www.famfamfam.com/lab/icons/
+ * Date:           18-Mar-2010
+ * Version:        1.1
+ * MODX version:   1.0.6-
+ */
+
+$tab_your_info = 1;
+$tab_online = 1;
+
+$iconResources = 1;
+$iconNewDoc = 1;
+$iconSearch = 1;
+$iconMessage = 1;
+
+$iconElements = 1;
+$iconSettings = 1;
+$iconFileManager = 1;
+$iconEventLog = 1;
+$iconSysInfo = 1;
+$iconHelp = 1;
+
+include_once(__DIR__ . '/welcome.php');
+if (is_file(__DIR__ . '/config.php')) {
+    include __DIR__ . '/config.php';
+}
+
+// Ensure the manager top frame accommodates the expanded navigation spacing.
+$revoMenuHeight = 86;
+if (!isset($modx->config['manager_menu_height']) || (int)$modx->config['manager_menu_height'] < $revoMenuHeight) {
+    $modx->config['manager_menu_height'] = (string)$revoMenuHeight;
+}
+
+if ($tab_your_info == 1) tabYourInfo();
+if ($tab_online == 1) tabOnlineUser();
+
+if ($iconResources == 1) iconResources();
+if ($iconNewDoc == 1) iconNewDoc();
+if ($iconSearch == 1) iconSearch();
+if ($iconMessage == 1) iconMessage();
+
+if ($iconElements == 1) iconElements();
+if ($iconFileManager == 1) iconFileManager();
+
+if ($iconSettings == 1) iconSettings();
+if ($iconEventLog == 1) iconEventLog();
+if ($iconSysInfo == 1) iconSysInfo();
+if ($iconHelp == 1) iconHelp();
+
+$style_path = 'media/style/' . $modx->config['manager_theme'] . '/';
+$images_path = manager_style_image_path();
+$icon_path = manager_style_image_path('icons');
+$tree_path = manager_style_image_path('tree');
+$misc_path = manager_style_image_path('misc');
+
+// Tree Menu Toolbar
+$_style['add_doc_tree'] = '<img src="' . $icon_path . 'page_add.png" />';
+$_style['add_weblink_tree'] = '<img src="' . $icon_path . 'link_add.png" />';
+$_style['collapse_tree'] = '<img src="' . $icon_path . 'arrow_up.png" />';
+$_style['empty_recycle_bin'] = '<img src="' . $icon_path . 'trash_full.png" />';
+$_style['empty_recycle_bin_empty'] = '<img src="' . $icon_path . 'trash.png" />';
+$_style['expand_tree'] = '<img src="' . $icon_path . 'arrow_down.png" />';
+$_style['hide_tree'] = '<img src="' . $icon_path . 'application_side_contract.png" />';
+$_style['refresh_tree'] = '<img src="' . $icon_path . 'refresh.png" />';
+$_style['show_tree'] = $icon_path . 'application_side_expand.png';
+$_style['sort_tree'] = '<img src="' . $icon_path . 'sort.png" />';
+
+
+// Tree Icons
+$_style['tree_blanknode'] = $tree_path . 'empty.png';
+$_style['tree_deletedpage'] = $tree_path . 'deletedpage.png';
+$_style['tree_folder'] = $tree_path . 'folder.png'; /* folder.png */
+$_style['tree_deletedfolder'] = $tree_path . 'deletedfolder.png';
+$_style['tree_folderopen'] = $tree_path . 'folderopen.png'; /* folder-open.png */
+$_style['tree_folder_secure'] = $tree_path . 'application_double_key.png';
+$_style['tree_folderopen_secure'] = $tree_path . 'application_double_key.png';
+$_style['tree_globe'] = $tree_path . 'globe.png';
+$_style['tree_linkgo'] = $tree_path . 'link_go.png';
+$_style['tree_minusnode'] = $tree_path . 'minusnode.png';
+$_style['tree_page'] = $tree_path . 'page.png';
+$_style['tree_page_home'] = $tree_path . 'application_home.png';
+$_style['tree_page_404'] = $tree_path . 'application_404.png';
+$_style['tree_page_hourglass'] = $tree_path . 'application_hourglass.png';
+$_style['tree_page_info'] = $tree_path . 'application_info.png';
+$_style['tree_page_blank'] = $tree_path . 'application.png';
+$_style['tree_page_css'] = $tree_path . 'application_css.png';
+$_style['tree_page_html'] = $tree_path . 'page.png';
+$_style['tree_page_xml'] = $tree_path . 'application_xml.png';
+$_style['tree_page_js'] = $tree_path . 'application_js.png';
+$_style['tree_page_rss'] = $tree_path . 'application_rss.png';
+$_style['tree_page_pdf'] = $tree_path . 'application_pdf.png';
+$_style['tree_page_word'] = $tree_path . 'application_word.png';
+$_style['tree_page_excel'] = $tree_path . 'application_excel.png';
+$_style['tree_page_jpg'] = $tree_path . 'picture.png';
+$_style['tree_page_png'] = $tree_path . 'picture.png';
+$_style['tree_page_gif'] = $tree_path . 'picture.png';
+$_style['tree_plusnode'] = $tree_path . 'plusnode.png';
+$_style['tree_showtree'] = '<img src="' . $tree_path . 'sitemap.png" align="absmiddle" />';
+$_style['tree_weblink'] = $tree_path . 'link_go.png';
+$_style['tree_draft'] = $tree_path . 'pencil.png';
+
+$_style['tree_page_secure'] = $tree_path . 'application_key.png';
+$_style['tree_page_blank_secure'] = $tree_path . 'application_html_secure.png';
+$_style['tree_page_css_secure'] = $tree_path . 'application_css_secure.png';
+$_style['tree_page_html_secure'] = $tree_path . 'application_html_secure.png';
+$_style['tree_page_xml_secure'] = $tree_path . 'application_xml_secure.png';
+$_style['tree_page_js_secure'] = $tree_path . 'application_js_secure.png';
+$_style['tree_page_rss_secure'] = $tree_path . 'application_rss_secure.png';
+$_style['tree_page_pdf_secure'] = $tree_path . 'application_pdf_secure.png';
+$_style['tree_page_word_secure'] = $tree_path . 'application_word_secure.png';
+$_style['tree_page_excel_secure'] = $tree_path . 'application_excel_secure.png';
+
+
+// Icons
+$_style['icons_add'] = $icon_path . 'add.png';
+$_style['icons_cal'] = $icon_path . 'cal.gif';
+$_style['icons_cal_nodate'] = $icon_path . 'cal_nodate.gif';
+$_style['icons_cancel'] = $icon_path . 'stop.png';
+$_style['icons_close'] = $icon_path . 'stop.png';
+$_style['icons_delete'] = $icon_path . 'delete.png';
+$_style['icons_delete_document'] = $icon_path . 'delete.png';
+$_style['icons_delete_complete'] = $icon_path . 'trash_full.png';
+$_style['icons_resource_overview'] = $icon_path . 'page_white_magnify.png';
+$_style['icons_resource_duplicate'] = $icon_path . 'page_white_copy.png';
+$_style['icons_edit_document'] = $icon_path . 'write.png';
+$_style['icons_email'] = $icon_path . 'email.png';
+$_style['icons_folder'] = $icon_path . 'folder.png';
+$_style['icons_home'] = $icon_path . 'home.gif';
+$_style['icons_information'] = $icon_path . 'information.png';
+$_style['icons_loading_doc_tree'] = $icon_path . 'information.png'; // top bar
+$_style['icons_mail'] = $icon_path . 'email.png'; // top bar
+$_style['icons_message_forward'] = $icon_path . 'forward.gif';
+$_style['icons_message_reply'] = $icon_path . 'reply.gif';
+$_style['icons_modules'] = $icon_path . '32x/modules.gif';
+$_style['icons_move_document'] = $icon_path . 'page_white_go.png';
+$_style['icons_new_document'] = $icon_path . 'page_white_add.png';
+$_style['icons_new_weblink'] = $icon_path . 'world_link.png';
+$_style['icons_preview_resource'] = $icon_path . 'page_white_magnify.png';
+$_style['icons_publish_document'] = $icon_path . 'clock_play.png';
+$_style['icons_refresh'] = $icon_path . 'refresh.png';
+$_style['icons_save'] = $icon_path . 'save.png';
+$_style['icons_set_parent'] = $icon_path . 'stick.gif';
+$_style['icons_table'] = $icon_path . 'table.gif';
+$_style['icons_undelete_resource'] = $icon_path . 'b092.gif';
+$_style['icons_unpublish_resource'] = $icon_path . 'clock_stop.png';
+$_style['icons_user'] = $icon_path . 'vcard.png';
+$_style['icons_view_document'] = $icon_path . 'context_view.gif';
+$_style['icons_weblink'] = $icon_path . 'world_link.png';
+$_style['icons_working'] = $icon_path . 'exclamation.png'; // top bar
+$_style['sort'] = $icon_path . 'sort.png';
+$_style['icons_date'] = $icon_path . 'date.gif';
+
+// Indicators
+$_style['icons_tooltip'] = $icon_path . 'b02.gif';
+$_style['icons_tooltip_over'] = $icon_path . 'b02_trans.gif';
+
+// Large Icons
+$_style['icons_backup_large'] = $icon_path . '32x/backup.png';
+$_style['icons_mail_large'] = $icon_path . '32x/mail.png';
+$_style['icons_mail_new_large'] = $icon_path . '32x/mail_new.png';
+$_style['icons_modules_large'] = $icon_path . '32x/modules.gif';
+$_style['icons_resources_large'] = $icon_path . '32x/resources.png';
+$_style['icons_elements_large'] = $icon_path . '32x/elements.png';
+$_style['icons_security_large'] = $icon_path . '32x/users.png';
+$_style['icons_webusers_large'] = $icon_path . '32x/users.png';
+$_style['icons_sysinfo_large'] = $icon_path . '32x/info.png';
+$_style['icons_search_large'] = $icon_path . '32x/search.png';
+$_style['icons_log_large'] = $icon_path . '32x/log.png';
+$_style['icons_files_large'] = $icon_path . '32x/files.png';
+$_style['icons_help_large'] = $icon_path . '32x/help.png';
+
+// Miscellaneous
+$_style['ajax_loader'] = '<p>' . $_lang['loading_page'] . '</p><p><img src="' . $misc_path . 'ajax-loader.gif" alt="Please wait" /></p>';
+$_style['tx'] = $misc_path . '_tx_.gif';

--- a/manager/media/style/LytmusBlue/welcome.php
+++ b/manager/media/style/LytmusBlue/welcome.php
@@ -1,0 +1,290 @@
+<?php
+if (!isset($modx) || !evo()->isLoggedin()) exit;
+
+$style_images_path = manager_style_image_path();
+$style_tree_path = manager_style_image_path('tree');
+
+function iconMessage()
+{
+    global $modx, $_lang;
+
+    if (getv('a') != 2) return;
+    if (evo()->hasPermission('messages')) {
+        $ph['imgsrc'] = (sessionv('nrnewmessages', 0) > 0) ? 'icons/32x/mail_new.png' : 'icons/32x/mail.png';
+        $ph['action'] = 'index.php?a=10';
+        $ph['title'] = $_lang['inbox'];
+        $modx->setPlaceholder('iconMessage', $modx->parseText(icontpl(), $ph));
+    }
+}
+
+function iconElements()
+{
+    global $modx, $_lang;
+
+    if (getv('a') != 2) return;
+    if (evo()->hasPermission('new_template') || evo()->hasPermission('edit_template') || evo()->hasPermission('new_snippet') || evo()->hasPermission('edit_snippet') || evo()->hasPermission('new_plugin') || evo()->hasPermission('edit_plugin')) {
+        $ph['imgsrc'] = 'icons/32x/elements.png';
+        $ph['action'] = 'index.php?a=76';
+        $ph['title'] = $_lang['element_management'];
+        $modx->setPlaceholder('iconElements', $modx->parseText(icontpl(), $ph));
+    }
+}
+
+function iconNewDoc()
+{
+    global $modx, $_lang;
+
+    if (getv('a') != 2) return;
+    if (evo()->hasPermission('new_document') || evo()->hasPermission('save_document')) {
+        $ph['imgsrc'] = 'icons/32x/newdoc.png';
+        $ph['action'] = 'index.php?a=4';
+        $ph['title'] = $_lang['add_resource'];
+        $modx->setPlaceholder('iconNewDoc', $modx->parseText(icontpl(), $ph));
+    }
+}
+
+function iconSettings()
+{
+    global $modx, $_lang;
+
+    if (getv('a') != 2) return;
+    if (evo()->hasPermission('settings')) {
+        $ph['imgsrc'] = 'icons/32x/settings.png';
+        $ph['action'] = 'index.php?a=17';
+        $ph['title'] = $_lang['edit_settings'];
+        $modx->setPlaceholder('iconSettings', $modx->parseText(icontpl(), $ph));
+    }
+}
+
+function iconResources()
+{
+    global $modx, $_lang;
+
+    if (getv('a') != 2) return;
+    if (evo()->hasPermission('view_document')) {
+        $ph['imgsrc'] = 'icons/32x/resources.png';
+        $ph['action'] = 'index.php?a=120';
+        $ph['title'] = $_lang['view_child_resources_in_container'];
+        $modx->setPlaceholder('iconResources', $modx->parseText(icontpl(), $ph));
+    }
+}
+
+function iconHelp()
+{
+    global $modx, $_lang;
+
+    if (getv('a') != 2) return;
+    if (evo()->hasPermission('help')) {
+        $ph['imgsrc'] = 'icons/32x/help.png';
+        $ph['action'] = 'index.php?a=9';
+        $ph['title'] = $_lang['help'];
+        $modx->setPlaceholder('iconHelp', $modx->parseText(icontpl(), $ph));
+    }
+}
+
+function iconFileManager()
+{
+    global $modx, $_lang;
+
+    if (getv('a') != 2) return;
+    if (evo()->hasPermission('file_manager')) {
+        $ph['imgsrc'] = 'icons/32x/files.png';
+        $ph['action'] = 'index.php?a=31';
+        $ph['title'] = $_lang['manage_files'];
+        $modx->setPlaceholder('iconFileManager', $modx->parseText(icontpl(), $ph));
+    }
+}
+
+function iconEventLog()
+{
+    global $modx, $_lang;
+
+    if (getv('a') != 2) return;
+    if (evo()->hasPermission('view_eventlog')) {
+        $ph['imgsrc'] = 'icons/32x/log.png';
+        $ph['action'] = 'index.php?a=114';
+        $ph['title'] = $_lang['eventlog'];
+        $modx->setPlaceholder('iconEventLog', $modx->parseText(icontpl(), $ph));
+    }
+}
+
+function iconSysInfo()
+{
+    global $modx, $_lang;
+
+    if (getv('a') != 2) return;
+    if (evo()->hasPermission('logs')) {
+        $ph['imgsrc'] = 'icons/32x/info.png';
+        $ph['action'] = 'index.php?a=53';
+        $ph['title'] = $_lang['view_sysinfo'];
+        $modx->setPlaceholder('iconSysInfo', $modx->parseText(icontpl(), $ph));
+    }
+}
+
+function iconSearch()
+{
+    global $modx, $_lang;
+
+    if (getv('a') != 2) return;
+    $ph['imgsrc'] = 'icons/32x/search.png';
+    $ph['action'] = 'index.php?a=71';
+    $ph['title'] = $_lang['search_resource'];
+    $modx->setPlaceholder('iconSearch', $modx->parseText(icontpl(), $ph));
+}
+
+function tabYourInfo()
+{
+    global $modx, $_lang;
+
+    if (getv('a') != 2) return;
+
+    $ph = $_lang;
+
+    if (sessionv('mgrLastlogin')) {
+        $Lastlogin = $modx->toDateFormat(sessionv('mgrLastlogin', 0) + config('server_offset_time'));
+    } else {
+        $Lastlogin = '-';
+    }
+
+    $ph['UserName'] = $modx->getLoginUserName();
+    $ph['name'] = sessionv('mgrPermissions.name');
+    $ph['Lastlogin'] = $Lastlogin;
+    $ph['Logincount'] = sessionv('mgrLogincount', 0) + 1;
+
+
+    $tpl = <<< TPL
+<p>[+yourinfo_message+]</p>
+<table border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td width="150">[+yourinfo_username+]</td>
+    <td width="20">&nbsp;</td>
+    <td><b>[+UserName+]</b></td>
+  </tr>
+  <tr>
+    <td>[+yourinfo_role+]</td>
+    <td>&nbsp;</td>
+    <td><b>[+name+]</b></td>
+  </tr>
+  <tr>
+    <td>[+yourinfo_previous_login+]</td>
+    <td>&nbsp;</td>
+    <td><b>[+Lastlogin+]</b></td>
+  </tr>
+  <tr>
+    <td>[+yourinfo_total_logins+]</td>
+    <td>&nbsp;</td>
+    <td><b>[+Logincount+]</b></td>
+  </tr>
+</table>
+TPL;
+    $user_info = $modx->parseText($tpl, $ph);
+
+    // recent document info
+    $uid = evo()->getLoginUserID();
+    $field = 'id, pagetitle, description, editedon, editedby';
+    $tbl_site_content = evo()->getFullTableName('site_content');
+    $where = "deleted=0 AND editedby='{$uid}'";
+    $rs = db()->select($field, $tbl_site_content, $where, 'editedon DESC', 10);
+
+    $recent_info = $_lang["activity_message"] . '<br /><br /><ul>';
+
+    if (db()->count($rs) < 1) {
+        $recent_info .= '<li>' . $_lang['no_activity_message'] . '</li>';
+    } else {
+        $tpl = '<li><b>[+editedon+]</b> - [[+id+]] <a href="index.php?a=3&amp;id=[+id+]">[+pagetitle+]</a>[+description+]</li>';
+        while ($row = db()->getRow($rs)) {
+            $row['editedon'] = $modx->toDateFormat($row['editedon']);
+            if ($row['description'] != '') {
+                $row['description'] = ' - ' . $row['description'];
+            }
+            $recent_info .= $modx->parseText($tpl, $row);
+        }
+    }
+    $recent_info .= '</ul>';
+
+    $modx->setPlaceholder('recent_docs', $_lang['recent_docs']);
+    $ph['UserInfo'] = $user_info;
+    $ph['RecentInfo'] = $recent_info;
+
+    $tpl = <<< TPL
+<div class="tab-page" id="tabYour">
+	<h2 class="tab">[+yourinfo_title+]</h2>
+    <script type="text/javascript">tpPane.addTabPage( document.getElementById( "tabYour" ) );</script>
+	<div class="sectionHeader">[+activity_title+]</div>
+	<div class="sectionBody">[+RecentInfo+]</div>
+	<div class="sectionHeader">[+yourinfo_title+]</div>
+	<div class="sectionBody">[+UserInfo+]</div>
+</div>
+TPL;
+    $tabYourInfo = $modx->parseText($tpl, $ph);
+    $modx->setPlaceholder('tabYourInfo', $tabYourInfo);
+}
+
+function tabOnlineUser()
+{
+    global $modx, $_lang, $style_tree_path;
+
+    if (getv('a') != 2) return;
+    $ph = $_lang;
+    $timetocheck = (time() - (60 * 20));//+$server_offset_time;
+
+    include_once($modx->config['core_path'] . 'actionlist.inc.php');
+    $rs = db()->select('*', '[+prefix+]active_users', "lasthit>'{$timetocheck}'", 'username ASC');
+    $total = db()->count($rs);
+    if ($total == 1) {
+        $ph['OnlineInfo'] = $modx->parseText('<p>[+no_active_users_found+]</p>', $ph);
+    } else {
+        $tr = [];
+        while ($row = db()->getRow($rs)) {
+            $currentaction = getAction($row['action'], $row['id']);
+            $webicon = ($row['internalKey'] < 0) ? '<img src="' . $style_tree_path . 'globe.png" alt="Web user" />' : '';
+            $tr[] = sprintf(
+                "<tr><td><b>%s</b></td><td>%s&nbsp;%d</td><td>%s</td><td>%s</td><td>%s</td></tr>",
+                $row['username'],
+                $webicon,
+                abs($row['internalKey']),
+                $row['ip'],
+                date('H:i:s', $row['lasthit'] + config('server_offset_time')),
+                $currentaction
+            );
+        }
+        if (!empty($tr)) $ph['userlist'] = implode("\n", $tr);
+        $ph['now'] = date('H:i:s', time() + config('server_offset_time'));
+        $tpl = <<< TPL
+<p>[+onlineusers_message+]<b>[+now+]</b>)</p>
+<table width="100%" class="grid">
+<thead>
+<tr>
+<th>[+onlineusers_user+]</th>
+<th>[+onlineusers_userid+]</th>
+<th>[+onlineusers_ipaddress+]</th>
+<th>[+onlineusers_lasthit+]</th>
+<th>[+onlineusers_action+]</th>
+</tr>
+</thead>
+<tbody>
+[+userlist+]
+</tbody>
+</table>
+TPL;
+        $ph['OnlineInfo'] = $modx->parseText($tpl, $ph);
+
+    }
+    $tpl = <<< TPL
+<div class="tab-page" id="tabOnline">
+	<h2 class="tab">[+online+]</h2>
+    <script type="text/javascript">tpPane.addTabPage( document.getElementById( "tabOnline" ) );</script>
+	<div class="sectionHeader">[+onlineusers_title+]</div>
+    <div class="sectionBody">[+OnlineInfo+]</div>
+</div>
+TPL;
+    $tabOnlineUser = $modx->parseText($tpl, $ph);
+    $modx->setPlaceholder('tabOnlineUser', $tabOnlineUser);
+}
+
+function icontpl()
+{
+    global $style_images_path;
+
+    return '<span class="wm_button" style="border:0"><a class="hometblink" href="[+action+]"><img src="' . $style_images_path . '[+imgsrc+]" /><br />[+title+]</a></span>' . "\n";
+}

--- a/manager/media/style/LytmusBlue/welcome.tpl
+++ b/manager/media/style/LytmusBlue/welcome.tpl
@@ -1,0 +1,61 @@
+<!-- welcome -->
+<div style="margin:8px;">
+    <div class="tab-pane" id="welcomePane" style="border:0">
+        <script type="text/javascript">
+            tpPane = new WebFXTabPane(document.getElementById("welcomePane"), false);
+        </script>
+
+        <!-- home tab -->
+        <div class="tab-page" id="tabhome" style="padding-left:0; padding-right:0;">
+            [+OnManagerWelcomePrerender+]
+            <h2 class="tab">[+welcome_title+]</h2>
+            <script type="text/javascript">tpPane.addTabPage(document.getElementById("tabhome"));</script>
+            <div class="sectionHeader">[+site_name+]</div>
+            <div class="sectionBody">
+                <table>
+                    <tr>
+                        <td width="120" align="center" valign="top">
+                            <img src='[+style_misc_path+]logo.png' alt='[+logo_slogan+]'/>
+                        </td>
+                        <td valign="top">
+                            [+OnManagerWelcomeHome+]
+                            <div style="overflow:hidden;zoom:1;margin-bottom:20px;">
+                                [+iconNewDoc+]
+                                [+iconResources+]
+                                [+iconSearch+]
+                                [+iconMessage+]
+                                [+iconHelp+]
+                            </div>
+                            <div style="overflow:hidden;zoom:1;margin-bottom:20px;">
+                                [+iconElements+]
+                                [+iconFileManager+]
+                                [+UserManagerIcon+]
+                                [+WebUserManagerIcon+]
+                            </div>
+                            <div>
+                                [+iconSettings+]
+                                [+BackupIcon+]
+                                [+iconEventLog+]
+                                [+iconSysInfo+]
+                            </div>
+                            <br style="clear:both"/><!--+Modules+--><br style="clear:both"/>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+        <!-- system check -->
+        <div class="tab-page" id="tabcheck" style="display:[+config_display+]; padding-left:0; padding-right:0;">
+            <h2 class="tab" style="display:[+config_display+]"><strong class="alert">[+settings_config+]</strong></h2>
+            <script type="text/javascript">tpPane.addTabPage(document.getElementById("tabcheck"));</script>
+            <div class="sectionHeader">[+configcheck_title+]</div>
+            <div class="sectionBody">
+                <img src="[+style_icons_path+]error.png"/>
+                [+config_check_results+]
+            </div>
+        </div>
+        [+tabYourInfo+]
+        [+tabOnlineUser+]
+        [+OnManagerWelcomeRender+]
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- add a new LytmusBlue manager theme using the provided blue and teal palette
- refresh navigation, action buttons, and section styling variables to match the new colors
- align context menu highlights with the updated theme hues

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69225be03360832dab535eb4b02ad8b5)