### PR TITLE
Fix deprecated dynamic properties in DocumentParser

### DIFF
--- a/manager/includes/document.parser.class.inc.php
+++ b/manager/includes/document.parser.class.inc.php
@@ -61,6 +61,7 @@ class DocumentParser
     public $jscripts = [];
     public $loadedjscripts = [];
     public $documentMap = [];
+    public $documentListing = [];
     public $forwards = 3;
     public $referenceListing;
     public $childrenList = [];
@@ -101,6 +102,7 @@ class DocumentParser
     public $revision;
     public $revisionObject;
     public $filter;
+    public $tvfilter;
 
     private $baseTime = ''; //タイムマシン(基本は現在時間)
 


### PR DESCRIPTION
## Summary
- declare DocumentParser::tvfilter to avoid dynamic property warnings from custom widget output filters
- add DocumentParser::documentListing to cover legacy document listing access without dynamic properties

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69257c4dadf8832d838fb8c672e5b4c1)