### PR TITLE
Skip empty default tags in widget

### DIFF
--- a/assets/plugins/managermanager/widgets/tags/tags.php
+++ b/assets/plugins/managermanager/widgets/tags/tags.php
@@ -68,7 +68,14 @@ function mm_widget_tags(
             foreach ($all_docs as $theDoc) {
                 $theTags = explode($delimiter, $theDoc['value']);
                 foreach ($theTags as $t) {
-                    $foundTags[trim($t)]++;
+                    $tag = trim($t);
+                    if ($tag === '') {
+                        continue;
+                    }
+                    if (!isset($foundTags[$tag])) {
+                        $foundTags[$tag] = 0;
+                    }
+                    $foundTags[$tag]++;
                 }
             }
             // Sort the TV values (case insensitively)
@@ -77,11 +84,12 @@ function mm_widget_tags(
 
         $default = explode(',', $default);
         foreach ($default as $k) {
-            if (strpos($k, '@fix') === 0) {
+            $tag = trim($k);
+            if ($tag === '' || strpos($tag, '@fix') === 0) {
                 continue;
             }
-            if (!isset($foundTags[$k])) {
-                $foundTags[$k] = 0;
+            if (!isset($foundTags[$tag])) {
+                $foundTags[$tag] = 0;
             }
         }
 


### PR DESCRIPTION
## Summary
- trim default tag values and ignore empties when building the tag list
- keep tag counters initialized to prevent undefined index warnings

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69257f0612c8832d8addf416ef1810e5)