### PR TITLE
Guard tag widget against empty TV values

### DIFF
--- a/assets/plugins/managermanager/widgets/tags/tags.php
+++ b/assets/plugins/managermanager/widgets/tags/tags.php
@@ -66,9 +66,21 @@ function mm_widget_tags(
             $all_docs = db()->makeArray($result);
 
             foreach ($all_docs as $theDoc) {
-                $theTags = explode($delimiter, $theDoc['value']);
+                $value = isset($theDoc['value']) ? (string)$theDoc['value'] : '';
+                if ($value === '') {
+                    continue;
+                }
+
+                $theTags = explode($delimiter, $value);
                 foreach ($theTags as $t) {
-                    $foundTags[trim($t)]++;
+                    $tag = trim($t);
+                    if ($tag === '') {
+                        continue;
+                    }
+                    if (!isset($foundTags[$tag])) {
+                        $foundTags[$tag] = 0;
+                    }
+                    $foundTags[$tag]++;
                 }
             }
             // Sort the TV values (case insensitively)
@@ -93,6 +105,10 @@ function mm_widget_tags(
                 jsSafe($t),
                 $display_count ? sprintf(' (%s)', $c) : ''
             );
+        }
+
+        if (!isset($mm_fields[$targetTv])) {
+            continue;
         }
 
         $tv_id = $mm_fields[$targetTv]['fieldname'];


### PR DESCRIPTION
## Summary
- ignore tag values that are missing or empty before splitting to avoid notices
- keep tag counting resilient to empty inputs when building suggestions

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69257d8d8704832db79e740f5d03dac4)