### PR TITLE
Handle empty defaults when building tag suggestions

### DIFF
--- a/assets/plugins/managermanager/widgets/tags/tags.php
+++ b/assets/plugins/managermanager/widgets/tags/tags.php
@@ -66,17 +66,32 @@ function mm_widget_tags(
             $all_docs = db()->makeArray($result);
 
             foreach ($all_docs as $theDoc) {
-                $theTags = explode($delimiter, $theDoc['value']);
+                $value = isset($theDoc['value']) ? (string)$theDoc['value'] : '';
+                if ($value === '') {
+                    continue;
+                }
+
+                $theTags = explode($delimiter, $value);
                 foreach ($theTags as $t) {
-                    $foundTags[trim($t)]++;
+                    $tag = trim($t);
+                    if ($tag === '') {
+                        continue;
+                    }
+                    if (!isset($foundTags[$tag])) {
+                        $foundTags[$tag] = 0;
+                    }
+                    $foundTags[$tag]++;
                 }
             }
             // Sort the TV values (case insensitively)
             uksort($foundTags, 'strcasecmp');
         }
 
-        $default = explode(',', $default);
-        foreach ($default as $k) {
+        $defaultTags = array_map('trim', explode(',', $default));
+        foreach ($defaultTags as $k) {
+            if ($k === '') {
+                continue;
+            }
             if (strpos($k, '@fix') === 0) {
                 continue;
             }
@@ -93,6 +108,10 @@ function mm_widget_tags(
                 jsSafe($t),
                 $display_count ? sprintf(' (%s)', $c) : ''
             );
+        }
+
+        if (!isset($mm_fields[$targetTv])) {
+            continue;
         }
 
         $tv_id = $mm_fields[$targetTv]['fieldname'];


### PR DESCRIPTION
## Summary
- trim default tag list entries and ignore blanks before applying fixed tags
- keep suggestion counts intact by skipping empty default placeholders

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69257d8d8704832db79e740f5d03dac4)