### PR TITLE
Free previous mysqli result before executing new query

### DIFF
--- a/manager/includes/extenders/dbapi/mysqli.inc.php
+++ b/manager/includes/extenders/dbapi/mysqli.inc.php
@@ -261,6 +261,11 @@ class DBAPI
             $sql = implode("\n", $sql);
         }
 
+        if ($this->rs instanceof mysqli_result) {
+            $this->rs->free();
+            $this->rs = null;
+        }
+
         $this->lastQuery = $sql;
         $result = $this->conn->query($sql);
         if (!$result) {


### PR DESCRIPTION
## Summary
- free any retained mysqli result set before executing a new query to avoid command sync errors

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69267e601e20832d809d0eab4958b983)