### PR TITLE
Enhance ddGetMultipleField documentation and defaults

### DIFF
--- a/assets/docs/ddgetmultiplefield.md
+++ b/assets/docs/ddgetmultiplefield.md
@@ -1,0 +1,54 @@
+# ddGetMultipleField スニペット
+
+`ddGetMultipleField` は `mm_ddMultipleFields` ウィジェットが保存する複合データを展開し、テンプレートを通じてレンダリングするためのスニペットです。DivanDesign 版と同じパラメータ構成を持ち、既存の呼び出しをそのまま移植できます。
+
+## 主な機能
+
+- **入力ソースの柔軟性**: TV (`&tv`) から値を取得するほか、`&inputString` で直接文字列を渡すことも可能。
+- **行・列のパース**: デフォルトで行区切り `||`、列区切り `::` を使用し、`&columns` で任意のプレースホルダー名を指定可能（未指定時は `col1`, `col2`, ... を自動生成）。
+- **フィルタリングと並び替え**: `&where` で JSON 形式の等価フィルターを指定し、`&sortBy` / `&sortDir` で並び替えが可能。
+- **表示制御**: `&offset` や `&display` でスキップ・上限を設定。`&display=all`（大文字小文字を区別しない）で全件表示。
+- **テンプレート適用**: 行テンプレート `&rowTpl`（または別名 `&tpl`）で各行を描画し、`&rowSeparator` で結合。さらに `&outerTpl` で全体をラップできます。
+- **プレースホルダー出力**: `&toPlaceholder` で出力を任意のプレースホルダーに保存。`&idxPlaceholder` により 1 始まりの行番号プレースホルダー名を変更可能。
+- **レガシー互換性**: `&owner` / `&ownerId` / `&api` など旧仕様のプレースホルダーも維持し、`&owner` が指定された場合はラップ時にこれらを渡します。
+
+## 典型的な呼び出し例
+
+```html
+[[ddGetMultipleField?
+    &tv=`gallery`
+    &columns=`title,description,url`
+    &rowTpl=`@CODE:<li><a href="[+url+]">[+title+]</a><br />[+description+]</li>`
+    &outerTpl=`@CODE:<ul>[+result+]</ul>`
+    &sortBy=`title`
+    &sortDir=`asc`
+]]
+```
+
+## パラメータ一覧
+
+| パラメータ | 説明 | デフォルト |
+| --- | --- | --- |
+| `docId` | 値を取得するドキュメントID。 | 現在のドキュメント |
+| `tv` | 複合データを保持する TV 名または ID。`inputString` 指定時は無視。 | — |
+| `inputString` | `rowDelimiter` / `colSeparator` で区切られた生の複合データ文字列。 | — |
+| `columns` | プレースホルダー名のカンマ区切りリスト。未指定時は `col1` などを自動生成。 | — |
+| `rowDelimiter` | 行の区切り文字列。 | `||` |
+| `colSeparator` | 行内の列の区切り文字列。 | `::` |
+| `rowTpl` / `tpl` | 各行を描画するチャンク名または `@CODE:` 付きテンプレート文字列。 | — |
+| `outerTpl` | 全体をラップするチャンク名または `@CODE:` 付きテンプレート文字列。`[+result+]` を受け取る。 | — |
+| `rowSeparator` | 行と行の間に挿入する文字列。 | — |
+| `offset` | 先頭からスキップする行数。 | `0` |
+| `display` | 表示する最大行数。空または `all`（大文字小文字を区別しない）で全件表示。 | `all` |
+| `sortBy` | 並び替えに使用する列キー。 | — |
+| `sortDir` | 並び順。`asc` または `desc`。 | `asc` |
+| `where` | 等価比較によるフィルター条件（JSON 形式）。 | — |
+| `idxPlaceholder` | 行番号（1 始まり）のプレースホルダー名。 | `idx` |
+| `toPlaceholder` | 出力先のプレースホルダー名。指定時は画面には出力しない。 | — |
+| `owner`, `ownerId`, `api` | レガシー呼び出し向けの互換プレースホルダー。`owner` が指定された場合にラップ時へ渡す。 | — |
+
+## 実装メモ
+
+- テンプレート取得は `@CODE:` を優先し、チャンクが見つからない場合は空文字を返します。
+- `where` が JSON として解釈できない場合はフィルターを無視し、入力データをそのまま処理します。
+- `display` や `offset` の計算後、行配列に `idxPlaceholder` で指定した番号が追加されるため、テンプレート側で行番号を簡単に参照できます。

--- a/assets/snippets/ddgetmultiplefield/README.md
+++ b/assets/snippets/ddgetmultiplefield/README.md
@@ -1,0 +1,54 @@
+# ddGetMultipleField
+
+`ddGetMultipleField` renders values saved by the `mm_ddMultipleFields` manager widget while keeping the same parameter layout as the original DivanDesign snippet. Existing snippets calls can be copied as-is, including legacy aliases such as `tpl`.
+
+## Installation
+
+1. Copy `assets/snippets/ddgetmultiplefield/snippet.ddgetmultiplefield.php` into your Evolution CMS installation.
+2. In the manager, create a snippet named **ddGetMultipleField** and paste the file contents.
+3. (Optional) Add the included documentation chunk as a reference for editors.
+
+## Behavior overview
+
+- Reads data from a ddMultipleFields TV (`tv`) or from a raw string (`inputString`).
+- Splits rows using `rowDelimiter` (default `||`) and columns using `colSeparator` (default `::`).
+- Generates placeholder names from `columns` or automatically (`col1`, `col2`, ...), and always exposes `[+idx+]` (configurable via `idxPlaceholder`).
+- Supports filtering through `where` (JSON key/value pairs), sorting by a column (`sortBy`/`sortDir`), offsetting, and limiting via `display` (case-insensitive `all` renders every row).
+- Renders each row with `rowTpl`/`tpl`, joins with `rowSeparator`, optionally wraps with `outerTpl`, and can output to a placeholder (`toPlaceholder`).
+- Legacy placeholders `owner`, `ownerId`, and `api` are preserved for compatibility; when `owner` is present they are passed into the final template.
+
+## Parameters
+
+| Parameter | Description | Default |
+| --- | --- | --- |
+| `docId` | Document id to read the TV from. | Current document id |
+| `tv` | TV name or id that stores the multiple field value. Ignored when `inputString` is provided. | — |
+| `inputString` | Raw multiple field string (rows separated by `rowDelimiter`, columns by `colSeparator`). | — |
+| `columns` | Comma-separated list of column keys used as placeholders inside templates. When omitted, keys are generated as `col1`, `col2`, etc. | — |
+| `rowDelimiter` | Delimiter between rows. | `||` |
+| `colSeparator` | Delimiter between columns in a row. | `::` |
+| `rowTpl` | Chunk name or `@CODE:` snippet for rendering each row. Falls back to `tpl` when empty. | — |
+| `tpl` | Legacy alias for `rowTpl`. Useful for existing calls that referenced the upstream snippet. | — |
+| `outerTpl` | Chunk name or `@CODE:` snippet wrapping the joined rows. Receives `[+result+]` placeholder. | — |
+| `rowSeparator` | Separator string inserted between rendered rows. | — |
+| `offset` | Number of rows to skip from the start. | `0` |
+| `display` | Maximum number of rows to render. Use `all` or empty (case-insensitive) to render everything. | `all` |
+| `sortBy` | Column key used for sorting. | — |
+| `sortDir` | Sort direction (`asc` or `desc`). | `asc` |
+| `where` | JSON object with equality filters, e.g. `{"status":"published"}`. | — |
+| `idxPlaceholder` | Placeholder name for the 1-based row index. | `idx` |
+| `toPlaceholder` | When set, the rendered output is stored in the given placeholder instead of being printed. | — |
+| `owner`, `ownerId`, `api` | Compatibility placeholders preserved for legacy calls; when `owner` is set, they are passed to the wrapping template. | — |
+
+## Example
+
+```html
+[[ddGetMultipleField?
+    &tv=`gallery`
+    &columns=`title,description,url`
+    &rowTpl=`@CODE:<li><a href="[+url+]">[+title+]</a><br />[+description+]</li>`
+    &outerTpl=`@CODE:<ul>[+result+]</ul>`
+    &sortBy=`title`
+    &sortDir=`asc`
+]]
+```

--- a/assets/snippets/ddgetmultiplefield/snippet.ddgetmultiplefield.php
+++ b/assets/snippets/ddgetmultiplefield/snippet.ddgetmultiplefield.php
@@ -1,0 +1,171 @@
+<?php
+if (!defined('MODX_BASE_PATH')) {
+    die('What are you doing? Get out of here!');
+}
+
+/**
+ * ddGetMultipleField
+ *
+ * A helper snippet for parsing ddMultipleFields TV values.
+ * Mirrors the public parameter interface of the upstream implementation
+ * to stay compatible with existing calls.
+ *
+ * @version 1.0.0
+ */
+
+$docId = isset($docId) && $docId !== '' ? (int) $docId : (int) evo()->documentIdentifier;
+$tv = $tv ?? '';
+$inputString = $inputString ?? '';
+$columns = $columns ?? '';
+$api = $api ?? '';
+$owner = $owner ?? '';
+$ownerId = isset($ownerId) ? (int) $ownerId : 0;
+$tpl = $tpl ?? '';
+$rowTpl = $rowTpl ?? '';
+$outerTpl = $outerTpl ?? '';
+$rowSeparator = $rowSeparator ?? '';
+$colSeparator = $colSeparator ?? '::';
+$rowDelimiter = $rowDelimiter ?? '||';
+$offset = isset($offset) ? (int) $offset : 0;
+$display = isset($display) ? $display : '';
+$sortBy = $sortBy ?? '';
+$sortDir = strtolower($sortDir ?? '');
+$where = $where ?? '';
+$toPlaceholder = $toPlaceholder ?? '';
+$idxPlaceholder = $idxPlaceholder ?? 'idx';
+
+$sortDir = $sortDir === 'desc' ? 'desc' : 'asc';
+
+$displayLower = strtolower((string) $display);
+$displayAll = $displayLower === '' || $displayLower === 'all';
+$display = $displayAll ? 0 : (int) $display;
+
+if ($tv === '' && $inputString === '') {
+    return '';
+}
+
+if ($inputString === '') {
+    $tvData = evo()->getTemplateVar($tv, '*', $docId);
+    $inputString = $tvData['value'] ?? '';
+}
+
+$inputString = trim((string) $inputString);
+if ($inputString === '') {
+    return '';
+}
+
+$rowsRaw = explode($rowDelimiter, $inputString);
+$rows = [];
+
+if ($columns !== '') {
+    $columns = array_values(array_filter(array_map('trim', explode(',', $columns)), 'strlen'));
+}
+
+$conditions = [];
+if ($where !== '') {
+    $decoded = json_decode($where, true);
+    if (is_array($decoded)) {
+        $conditions = $decoded;
+    }
+}
+
+foreach ($rowsRaw as $rowIndex => $row) {
+    $values = explode($colSeparator, $row);
+    if (!count(array_filter($values, 'strlen'))) {
+        continue;
+    }
+
+    if (!$columns) {
+        $columns = [];
+        foreach ($values as $index => $value) {
+            $columns[] = "col" . ($index + 1);
+        }
+    }
+
+    $item = [];
+    foreach ($values as $index => $value) {
+        $key = $columns[$index] ?? "col" . ($index + 1);
+        $item[$key] = trim($value);
+    }
+
+    if ($conditions) {
+        $matched = true;
+        foreach ($conditions as $key => $expected) {
+            if (($item[$key] ?? null) != $expected) {
+                $matched = false;
+                break;
+            }
+        }
+        if (!$matched) {
+            continue;
+        }
+    }
+
+    $item[$idxPlaceholder] = $rowIndex + 1;
+    $rows[] = $item;
+}
+
+if ($sortBy !== '') {
+    usort($rows, static function (array $left, array $right) use ($sortBy, $sortDir) {
+        $leftValue = $left[$sortBy] ?? '';
+        $rightValue = $right[$sortBy] ?? '';
+        if ($leftValue == $rightValue) {
+            return 0;
+        }
+        if ($sortDir === 'desc') {
+            return $leftValue < $rightValue ? 1 : -1;
+        }
+        return $leftValue > $rightValue ? 1 : -1;
+    });
+}
+
+if ($offset > 0) {
+    $rows = array_slice($rows, $offset);
+}
+
+if (!$displayAll && $display > 0) {
+    $rows = array_slice($rows, 0, $display);
+}
+
+function ddgmfGetTpl(string $template): string
+{
+    if ($template === '') {
+        return '';
+    }
+    if (strpos($template, '@CODE:') === 0) {
+        return substr($template, 6);
+    }
+    return evo()->getChunk($template) ?: '';
+}
+
+$tpl = ddgmfGetTpl($tpl);
+$rowTpl = ddgmfGetTpl($rowTpl ?: $tpl);
+$outerTpl = ddgmfGetTpl($outerTpl);
+
+$outputRows = [];
+foreach ($rows as $row) {
+    $outputRows[] = evo()->parseText($rowTpl, $row);
+}
+
+$result = implode($rowSeparator, $outputRows);
+
+if ($outerTpl !== '') {
+    $result = evo()->parseText($outerTpl, ['result' => $result]);
+}
+
+if ($owner !== '') {
+    $ownerPlaceholders = [
+        'result' => $result,
+        'owner' => $owner,
+        'ownerId' => $ownerId,
+        'api' => $api,
+    ];
+    $result = evo()->parseText($outerTpl ?: $rowTpl, $ownerPlaceholders);
+}
+
+if ($toPlaceholder !== '') {
+    evo()->setPlaceholder($toPlaceholder, $result);
+    return '';
+}
+
+return $result;


### PR DESCRIPTION
## Summary
- make the `display` limiter accept case-insensitive `all` to match expected legacy behavior
- expand the snippet README with installation, behavior, and parameter details
- add a dedicated Japanese documentation page for ddGetMultipleField

## Testing
- php -l assets/snippets/ddgetmultiplefield/snippet.ddgetmultiplefield.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692922c0490c832d8eabec4b4ddfda95)