### PR TITLE
Add installer guard requiring install-config for setup access

### DIFF
--- a/install/functions.php
+++ b/install/functions.php
@@ -663,6 +663,38 @@ function guardInstallerAccess()
     enforceInstallBasicAuth($config);
 }
 
+function isManagerAuthenticated()
+{
+    return sessionv('mgrValidated') && sessionv('mgrInternalKey');
+}
+
+function guardUpgradeAccess()
+{
+    if (!isManagerAuthenticated()) {
+        renderUpgradeAuthRequired();
+    }
+}
+
+function renderUpgradeAuthRequired()
+{
+    $ph = ph();
+    $ph['install_config_title'] = lang('upgrade_auth_required_title');
+    $ph['install_config_message'] = lang('upgrade_auth_required_message');
+    $ph['upgrade_auth_login_link'] = lang('upgrade_auth_login_link');
+    $ph['upgrade_auth_after_login'] = lang('upgrade_auth_after_login');
+    $ph['manager_url'] = MODX_MANAGER_URL;
+    $ph['content'] = parseText(
+        file_get_contents(MODX_SETUP_PATH . 'tpl/upgrade_auth.tpl'),
+        $ph
+    );
+
+    echo evo()->parseText(
+        file_get_contents(MODX_SETUP_PATH . 'tpl/template.tpl'),
+        $ph
+    );
+    exit;
+}
+
 function renderInstallConfigNotice($messageKey)
 {
     $ph = ph();

--- a/install/index.php
+++ b/install/index.php
@@ -70,10 +70,12 @@ if ($action === 'mode') {
 
 $_lang = includeLang(lang_name());
 
-// アップグレード時は install-config.php の制限をスキップ
-// 既存インストールでは管理者権限を持つユーザーがアクセスする想定
+// 新規インストール時: install-config.php による保護
+// アップグレード時: Evolution CMS の管理者認証を要求
 if (!sessionv('is_upgradeable')) {
     guardInstallerAccess();
+} else {
+    guardUpgradeAccess();
 }
 
 $errors = 0;

--- a/install/index.php
+++ b/install/index.php
@@ -70,6 +70,8 @@ if ($action === 'mode') {
 
 $_lang = includeLang(lang_name());
 
+guardInstallerAccess();
+
 $errors = 0;
 
 $ph = ph();

--- a/install/index.php
+++ b/install/index.php
@@ -70,7 +70,11 @@ if ($action === 'mode') {
 
 $_lang = includeLang(lang_name());
 
-guardInstallerAccess();
+// アップグレード時は install-config.php の制限をスキップ
+// 既存インストールでは管理者権限を持つユーザーがアクセスする想定
+if (!sessionv('is_upgradeable')) {
+    guardInstallerAccess();
+}
 
 $errors = 0;
 

--- a/install/install-config.sample.php
+++ b/install/install-config.sample.php
@@ -1,0 +1,12 @@
+<?php
+return [
+    // BASIC authentication credentials to protect the installer. Leave both empty to disable BASIC authentication.
+    'basic_auth' => [
+        'user' => 'installer',
+        'password' => 'change-me',
+    ],
+    // IP addresses allowed to access the installer. Leave empty to allow access from any address.
+    'allowed_ips' => [
+        '127.0.0.1',
+    ],
+];

--- a/install/langs/english.inc.php
+++ b/install/langs/english.inc.php
@@ -206,3 +206,7 @@ $_lang["install_config_step1"] = 'Copy %s to %s.';
 $_lang["install_config_step2"] = 'Edit <span class="mono">install-config.php</span> to set BASIC authentication and/or allowed IP addresses.';
 $_lang["install_config_step3"] = 'Reload this page after saving the configuration file.';
 $_lang["install_config_footer"] = 'Only administrators with server access should create this file to run the installer.';
+$_lang["upgrade_auth_required_title"] = 'Manager authentication required for upgrade';
+$_lang["upgrade_auth_required_message"] = '<p>To perform an upgrade, you must be logged into the Evolution CMS manager.</p>';
+$_lang["upgrade_auth_login_link"] = 'Log in to manager';
+$_lang["upgrade_auth_after_login"] = 'After logging in, return to this page to continue the upgrade.';

--- a/install/langs/english.inc.php
+++ b/install/langs/english.inc.php
@@ -198,3 +198,11 @@ $_lang['utf8mb4_conversion_skip'] = 'Skip conversion and keep existing utf8 tabl
 $_lang['utf8mb4_conversion_tables_intro'] = 'Tables targeted for conversion:';
 $_lang['utf8mb4_conversion_tables_none'] = 'No tables require conversion.';
 $_lang["begin_install_msg"] = '<p>MODx is not currently installed or the configuration file cannot be found.</p><p>Do you want to install now?</p>';
+$_lang["install_config_title"] = 'Installer access control';
+$_lang["install_config_missing_message"] = 'Installation cannot continue because <span class="mono">install-config.php</span> is missing.';
+$_lang["install_config_ip_message"] = 'Installation cannot continue because access from your IP address is not allowed. Please update <span class="mono">allowed_ips</span> in <span class="mono">install-config.php</span>.';
+$_lang["install_config_auth_message"] = 'Authentication is required to access the installer. Please enter the BASIC authentication credentials defined in <span class="mono">install-config.php</span>.';
+$_lang["install_config_step1"] = 'Copy %s to %s.';
+$_lang["install_config_step2"] = 'Edit <span class="mono">install-config.php</span> to set BASIC authentication and/or allowed IP addresses.';
+$_lang["install_config_step3"] = 'Reload this page after saving the configuration file.';
+$_lang["install_config_footer"] = 'Only administrators with server access should create this file to run the installer.';

--- a/install/langs/japanese-utf8.inc.php
+++ b/install/langs/japanese-utf8.inc.php
@@ -207,3 +207,11 @@ $_lang['checking_if_temp_writable'] = '<span class="mono">/temp</span>ディレ�
 $_lang["welcome_message_upd_text"] = 'MODXのアップデートは簡単。インストーラの説明に従って進めてください。';
 $_lang["welcome_message_upd_welcome"] = 'MODXのアップデートを開始します。';
 $_lang["begin_install_msg"] = '<p>MODXがインストールされていないか設定ファイルが見つかりません。</p><p>今すぐインストールしますか？</p>';
+$_lang["install_config_title"] = 'インストーラーのアクセス制御';
+$_lang["install_config_missing_message"] = '<span class="mono">install-config.php</span> が存在しないため、インストールを続行できません。';
+$_lang["install_config_ip_message"] = '現在の接続元IPアドレスからはインストールを実行できません。<span class="mono">install-config.php</span> の <span class="mono">allowed_ips</span> を更新してください。';
+$_lang["install_config_auth_message"] = 'インストーラーにアクセスするには BASIC 認証が必要です。<span class="mono">install-config.php</span> で設定したユーザー名とパスワードを入力してください。';
+$_lang["install_config_step1"] = '%s を %s にコピーしてください。';
+$_lang["install_config_step2"] = '<span class="mono">install-config.php</span> を編集し、BASIC 認証のユーザー名とパスワード、または <span class="mono">allowed_ips</span> を設定してください。';
+$_lang["install_config_step3"] = '設定ファイルを保存したら、このページを再読み込みしてください。';
+$_lang["install_config_footer"] = 'インストールを実行できるのはサーバーの操作権限を持つ管理者のみとしてください。';

--- a/install/langs/japanese-utf8.inc.php
+++ b/install/langs/japanese-utf8.inc.php
@@ -215,3 +215,7 @@ $_lang["install_config_step1"] = '%s を %s にコピーしてください。';
 $_lang["install_config_step2"] = '<span class="mono">install-config.php</span> を編集し、BASIC 認証のユーザー名とパスワード、または <span class="mono">allowed_ips</span> を設定してください。';
 $_lang["install_config_step3"] = '設定ファイルを保存したら、このページを再読み込みしてください。';
 $_lang["install_config_footer"] = 'インストールを実行できるのはサーバーの操作権限を持つ管理者のみとしてください。';
+$_lang["upgrade_auth_required_title"] = 'アップグレードには管理者認証が必要です';
+$_lang["upgrade_auth_required_message"] = '<p>アップグレードを実行するには、Evolution CMS の管理画面にログインしている必要があります。</p>';
+$_lang["upgrade_auth_login_link"] = '管理画面にログイン';
+$_lang["upgrade_auth_after_login"] = 'ログイン後、このページに戻ってアップグレードを続行してください。';

--- a/install/style.css
+++ b/install/style.css
@@ -822,3 +822,28 @@ select::-ms-expand {
 input#adminemail {
     width: 350px;
 }
+
+.install-config-guard {
+    background: #fff4e5;
+    border: 1px solid #f5c46b;
+    border-radius: 6px;
+    margin: 1em 0;
+    padding: 1.2em;
+}
+
+.install-config-remote {
+    margin: 0.2em 0 1em;
+}
+
+.install-config-instructions ol {
+    margin-top: 0.8em;
+}
+
+.install-config-instructions li + li {
+    margin-top: 0.4em;
+}
+
+.install-config-footer {
+    margin-top: 1em;
+    color: #5a5a5a;
+}

--- a/install/tpl/install_config.tpl
+++ b/install/tpl/install_config.tpl
@@ -1,0 +1,13 @@
+<div class="sectionBody install-config-guard">
+    <h2>[+install_config_title+]</h2>
+    <p class="install-config-remote"><strong>REMOTE_ADDR :</strong> <span class="mono">[+remote_addr+]</span></p>
+    <div class="install-config-instructions">
+        <p>[+install_config_message+]</p>
+        <ol>
+            <li>[+install_config_step1+]</li>
+            <li>[+install_config_step2+]</li>
+            <li>[+install_config_step3+]</li>
+        </ol>
+    </div>
+    <p class="install-config-footer">[+install_config_footer+]</p>
+</div>

--- a/install/tpl/upgrade_auth.tpl
+++ b/install/tpl/upgrade_auth.tpl
@@ -1,0 +1,14 @@
+<div class="sectionBody upgrade-auth-guard">
+    <h2>[+install_config_title+]</h2>
+    <div class="upgrade-auth-instructions">
+        [+install_config_message+]
+        <p style="margin-top: 2em;">
+            <a href="[+manager_url+]" class="btn btn-primary" target="_blank">
+                [+upgrade_auth_login_link+]
+            </a>
+        </p>
+        <p style="margin-top: 1em; color: #666;">
+            [+upgrade_auth_after_login+]
+        </p>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- add install-config.php requirement with BASIC auth/IP checks before running installer
- provide localized instructions and styling for the new installer access guard page
- ship install-config.sample.php template to guide configuration

## Testing
- php -l install/functions.php
- php -l install/index.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69337d0b1d44832da88745c19eba4e7c)