### PR TITLE
Escape where helper values to avoid malformed queries

### DIFF
--- a/manager/includes/extenders/ex_dbapi.php
+++ b/manager/includes/extenders/ex_dbapi.php
@@ -39,6 +39,9 @@ function where($field, $op, $value = null)
         $value = $op;
         $op = '=';
     }
+
+    $value = db()->escape($value);
+
     return sprintf(
         strpos($field, '`') === false ? '`%s` %s "%s"' : '%s %s "%s"',
         $field, $op, $value
@@ -72,4 +75,3 @@ function and_where_in($field, $values = [])
     }
     return 'AND ' . where_in($field, $values);
 }
-


### PR DESCRIPTION
## Summary
- escape values passed to the where() helper to avoid malformed SQL queries

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694bef9f6bec832d92e852e03941df97)