### PR TITLE
PHP 8.5 の no-op リソース解放呼び出しを削除

### DIFF
--- a/manager/includes/extenders/ex_export_site.php
+++ b/manager/includes/extenders/ex_export_site.php
@@ -266,7 +266,6 @@ class EXPORT_SITE
 
         // Close reusable curl handle
         if ($this->curl) {
-            @curl_close($this->curl);
             $this->curl = null;
         }
 

--- a/manager/media/browser/mcpuk/connectors/Commands/GetUploadProgress.php
+++ b/manager/media/browser/mcpuk/connectors/Commands/GetUploadProgress.php
@@ -73,6 +73,5 @@ class GetUploadProgress extends Base
         $response->addChild('RefreshURL', ['url' => $refreshURL]);
 
         $this->outputXml($response);
-        xml_parser_free($parser);
     }
 }


### PR DESCRIPTION
Summary:
- Remove deprecated resource release calls (curl_close, xml_parser_free) that are no-ops and noisy on PHP 8.5.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f86506d90832d9e2b9eb128c958cb)