### PR TITLE
Ci/improved

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,27 @@
 ## Language
 
-- Always generate summaries, commit messages, and pull request descriptions in Japanese.
-- Use clear and concise Japanese suitable for release notes and technical documentation.
+- すべて日本語で記述すること。
+- 英語は明示的に求められた場合を除き使用しない。
+
+## PR Summary Format
+
+- PR Summary は必ず箇条書きで記述すること。
+- 説明的な詳細な文章ではなく、要点のみを簡潔に列挙すること。
+- 見出しや装飾（太字・コードブロックなど）は使用しない。
+
+## Writing Style
+
+- 敬体（です・ます調）は使用しない。
+- 常体（だ・である調）で統一する。
+- 技術文書・リリースノート向けの簡潔な文体を用いる。
+
+## Content Rules
+
+- 変更点のみを記載し、背景説明や推測は書かない。
+- 破壊的変更がある場合は、最初の箇条書きで明示する。
+- 実装詳細ではなく「利用者・開発者にとっての影響」を優先する。
+
+## Release Notes Compatibility
+
+- PR Summary は、そのまま Release Notes に転記できる内容とする。
+- 必要に応じて、Release Notes 用に別途要約を作成すること。

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,4 @@
+## Language
+
+- Always generate summaries, commit messages, and pull request descriptions in Japanese.
+- Use clear and concise Japanese suitable for release notes and technical documentation.

--- a/.github/workflows/pr-auto-label.yml
+++ b/.github/workflows/pr-auto-label.yml
@@ -1,40 +1,52 @@
-name: Auto Assign Labels from Conventional Commits
+name: Assign labels based on Conventional Commits
 
 on:
   pull_request:
     types: [opened, reopened, synchronize, edited]
 
 jobs:
-  label_pr:
+  auto_label:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - name: Assign labels based on Conventional Commits
+      - name: Assign labels
         uses: mauroalderete/action-assign-labels@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           conventional-commits: |
-            - type: 'feat'
-              labels: ['新機能']
-            - type: 'fix'
-              labels: ['バグ修正']
-            - type: 'enhancement'
-              labels: ['改善／拡張']
-            - type: 'refactor'
-              labels: ['リファクタ']
-            - type: 'perf'
-              labels: ['パフォーマンス']
-            - type: 'docs'
-              labels: ['ドキュメント']
-            - type: 'test'
-              labels: ['テスト']
-            - type: 'ci/cd'
-              labels: ['CI/CD']
-            - type: 'chore'
-              labels: ['雑務']
-            - type: 'security'
-              labels: ['セキュリティ']
-            - type: 'breaking_change'
-              labels: ['破壊的変更']
+            conventional-commits:
+              - type: 'feat'
+                nouns: ['feat']
+                labels: ['新機能']
+              - type: 'fix'
+                nouns: ['fix']
+                labels: ['バグ修正']
+              - type: 'enhancement'
+                nouns: ['enhancement']
+                labels: ['改善／拡張']
+              - type: 'refactor'
+                nouns: ['refactor']
+                labels: ['リファクタ']
+              - type: 'perf'
+                nouns: ['perf']
+                labels: ['パフォーマンス']
+              - type: 'docs'
+                nouns: ['docs']
+                labels: ['ドキュメント']
+              - type: 'test'
+                nouns: ['test']
+                labels: ['テスト']
+              - type: 'ci'
+                nouns: ['ci']
+                labels: ['CI/CD']
+              - type: 'chore'
+                nouns: ['chore']
+                labels: ['雑務']
+              - type: 'security'
+                nouns: ['security']
+                labels: ['セキュリティ']
+              - type: 'breaking_change'
+                nouns: ['breaking change']
+                labels: ['破壊的変更']


### PR DESCRIPTION
This pull request updates the workflow for auto-labeling pull requests and introduces new instructions for writing PR summaries. The main changes include improvements to the GitHub Actions workflow for label assignment and the addition of detailed guidelines for PR summary formatting and language.

**Workflow improvements:**

* `pr-auto-label.yml`のジョブ名・ステップ名をわかりやすく変更し、`actions/checkout`をv4に更新した（[.github/workflows/pr-auto-label.ymlL1-R51](diffhunk://#diff-05e531e0e7c984ba3e306dd55f5aa2031c47f24643ee855613e999caa895b5d3L1-R51)）
* Conventional Commitsの各タイプごとに`nouns`を追加し、ラベル付与の柔軟性を向上させた（[.github/workflows/pr-auto-label.ymlL1-R51](diffhunk://#diff-05e531e0e7c984ba3e306dd55f5aa2031c47f24643ee855613e999caa895b5d3L1-R51)）
* `ci/cd`タイプを`ci`に変更し、対応するラベルも調整した（[.github/workflows/pr-auto-label.ymlL1-R51](diffhunk://#diff-05e531e0e7c984ba3e306dd55f5aa2031c47f24643ee855613e999caa895b5d3L1-R51)）

**ドキュメント追加:**

* PRサマリーの日本語記述ルール・フォーマット・文体・内容・リリースノート互換性についての詳細なガイドラインを`.github/copilot-instructions.md`に追加した（[.github/copilot-instructions.mdR1-R27](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R1-R27)）