### PR TITLE
TopicPathのテーマ設定のエラーハンドリングを改善

### DIFF
--- a/assets/snippets/topicpath/topicpath.class.inc.php
+++ b/assets/snippets/topicpath/topicpath.class.inc.php
@@ -71,7 +71,8 @@ class TopicPath
         elseif (in_array(docid(), $this->disabledOn)) return;
         $default = include(__DIR__ . '/config/default.php');
         if (!isset($default[$this->theme])) {
-            throw new Exception("Theme '{$this->theme}' not found in configuration.");
+            $available = implode(', ', array_keys($default));
+            throw new Exception("設定に存在しないテーマ '{$this->theme}' が指定されています。利用可能なテーマ: {$available}");
         }
         $tpl = $default[$this->theme];
         $tpl = array_merge($tpl, $this->tpl);

--- a/assets/snippets/topicpath/topicpath.install_base.tpl
+++ b/assets/snippets/topicpath/topicpath.install_base.tpl
@@ -7,7 +7,7 @@
  * @category	snippet
  * @version 	2.0.4
  * @license 	http://www.gnu.org/copyleft/gpl.html GNU Public License (GPL)
- * @internal	@properties &theme=Theme;list;string,list;string
+ * @internal	@properties &theme=Theme;list;simple,list,bootstrap,bootstrap5,microdata,raw;simple
  * @internal	@modx_category Navigation
  * @internal    @installset base, sample
  * @author  	yamamoto https://kyms.jp


### PR DESCRIPTION
- TopicPathで存在しないテーマが指定された場合に、利用可能なテーマ一覧を示した例外を送出するようにした
- 不正なテーマ指定時のフォールバックを廃止し、設定ミスを明示的に検出できるようにした

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a56ab2d08832d9b2b40204d5a2430)