### PR TITLE
Fix Ditto TV inheritance processing by setting docid

### DIFF
--- a/assets/snippets/ditto/classes/ditto.class.inc.php
+++ b/assets/snippets/ditto/classes/ditto.class.inc.php
@@ -829,12 +829,15 @@ class ditto
         );
         $total = db()->count($rs);
         $docs = [];
-        while ($row = db()->getRow($rs)) {
-            $k = '#' . $row['contentid'];
-            $row['docid'] = $row['contentid'];
+        $appendTvValue = function ($row, $contentId, $name) use (&$docs) {
+            $k = '#' . $contentId;
+            $row['docid'] = $contentId;
             $v = evo()->tvProcessor($row);
-            $docs[$k][$row['name']] = $v;
-            $docs[$k]['tv' . $row['name']] = $v;
+            $docs[$k][$name] = $v;
+            $docs[$k]['tv' . $name] = $v;
+        };
+        while ($row = db()->getRow($rs)) {
+            $appendTvValue($row, $row['contentid'], $row['name']);
         }
         if ($total == count($docIDs)) {
             return $docs;
@@ -854,10 +857,7 @@ class ditto
                 $k = '#' . $id;
                 if (!isset($docs[$k])) {
                     $row['contentid'] = $id;
-                    $row['docid'] = $id;
-                    $v = evo()->tvProcessor($row);
-                    $docs[$k][$tvname] = $v;
-                    $docs[$k]['tv' . $tvname] = $v;
+                    $appendTvValue($row, $id, $tvname);
                 }
             }
             return $docs;
@@ -870,10 +870,7 @@ class ditto
             if (isset($docs[$k])) {
                 continue;
             }
-            $row['docid'] = $id;
-            $v = evo()->tvProcessor($row);
-            $docs[$k][$tvname] = $v;
-            $docs[$k]['tv' . $tvname] = $v;
+            $appendTvValue($row, $id, $tvname);
         }
         return $docs;
     }

--- a/assets/snippets/ditto/classes/ditto.class.inc.php
+++ b/assets/snippets/ditto/classes/ditto.class.inc.php
@@ -829,15 +829,8 @@ class ditto
         );
         $total = db()->count($rs);
         $docs = [];
-        $appendTvValue = function ($row, $contentId, $name) use (&$docs) {
-            $k = '#' . $contentId;
-            $row['docid'] = $contentId;
-            $v = evo()->tvProcessor($row);
-            $docs[$k][$name] = $v;
-            $docs[$k]['tv' . $name] = $v;
-        };
         while ($row = db()->getRow($rs)) {
-            $appendTvValue($row, $row['contentid'], $row['name']);
+            $this->appendTvValue($docs, $row, $row['contentid'], $row['name']);
         }
         if ($total == count($docIDs)) {
             return $docs;
@@ -857,7 +850,7 @@ class ditto
                 $k = '#' . $id;
                 if (!isset($docs[$k])) {
                     $row['contentid'] = $id;
-                    $appendTvValue($row, $id, $tvname);
+                    $this->appendTvValue($docs, $row, $id, $tvname);
                 }
             }
             return $docs;
@@ -870,9 +863,23 @@ class ditto
             if (isset($docs[$k])) {
                 continue;
             }
-            $appendTvValue($row, $id, $tvname);
+            $this->appendTvValue($docs, $row, $id, $tvname);
         }
         return $docs;
+    }
+
+    // ---------------------------------------------------
+    // Function: appendTvValue
+    // Append processed TV output to documents array
+    // ---------------------------------------------------
+
+    function appendTvValue(&$docs, $row, $contentId, $name)
+    {
+        $k = '#' . $contentId;
+        $row['docid'] = $contentId;
+        $v = evo()->tvProcessor($row);
+        $docs[$k][$name] = $v;
+        $docs[$k]['tv' . $name] = $v;
     }
 
     // ---------------------------------------------------

--- a/assets/snippets/ditto/classes/ditto.class.inc.php
+++ b/assets/snippets/ditto/classes/ditto.class.inc.php
@@ -831,6 +831,7 @@ class ditto
         $docs = [];
         while ($row = db()->getRow($rs)) {
             $k = '#' . $row['contentid'];
+            $row['docid'] = $row['contentid'];
             $v = evo()->tvProcessor($row);
             $docs[$k][$row['name']] = $v;
             $docs[$k]['tv' . $row['name']] = $v;
@@ -853,6 +854,7 @@ class ditto
                 $k = '#' . $id;
                 if (!isset($docs[$k])) {
                     $row['contentid'] = $id;
+                    $row['docid'] = $id;
                     $v = evo()->tvProcessor($row);
                     $docs[$k][$tvname] = $v;
                     $docs[$k]['tv' . $tvname] = $v;
@@ -868,6 +870,7 @@ class ditto
             if (isset($docs[$k])) {
                 continue;
             }
+            $row['docid'] = $id;
             $v = evo()->tvProcessor($row);
             $docs[$k][$tvname] = $v;
             $docs[$k]['tv' . $tvname] = $v;


### PR DESCRIPTION
### Motivation
- Dittoの`appendTV()`が`@INHERIT`やデフォルト値を各ドキュメント文脈で正しく解決するための`docid`情報を渡しておらず、Image等のTV出力が表示されない問題を解消するための修正です。

### Description
- `assets/snippets/ditto/classes/ditto.class.inc.php`の`appendTV()`内で、取得したTV行やデフォルト処理の各分岐の前に`$row['docid']`を該当する`contentid`/`$id`で設定するように3箇所挿入しました（例: ``$row['docid'] = $row['contentid'];`` / ``$row['docid'] = $id;``）。

### Testing
- 自動テストは実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69719e234820832dbcf552cbec647e7a)