### PR TITLE
Fix file browser root label for resource types

### DIFF
--- a/manager/media/browser/mcpuk/frmactualfolder.html
+++ b/manager/media/browser/mcpuk/frmactualfolder.html
@@ -19,7 +19,7 @@
 <head>
     <link href="browser.css" type="text/css" rel="stylesheet">
     <script type="text/javascript">
-        function buildBreadcrumb(folderPath) {
+        function buildBreadcrumb(resourceType, folderPath) {
             var pathEl = document.getElementById('tdName');
 
             if (!pathEl) {
@@ -73,12 +73,12 @@
             };
 
             if (!parts.length) {
-                pathEl.appendChild(createCurrent('images'));
+                pathEl.appendChild(createCurrent(getResourceTypeLabel(resourceType)));
 
                 return;
             }
 
-            pathEl.appendChild(createLink('images', '/'));
+            pathEl.appendChild(createLink(getResourceTypeLabel(resourceType), '/'));
 
             parts.forEach(function (part, index) {
                 var pathForLink = currentPath + part + '/';
@@ -92,7 +92,19 @@
         }
 
         function SetCurrentFolder(resourceType, folderPath) {
-            buildBreadcrumb(folderPath);
+            buildBreadcrumb(resourceType, folderPath);
+        }
+
+        function getResourceTypeLabel(resourceType) {
+            if (resourceType === 'files') {
+                return 'Files';
+            }
+
+            if (resourceType === 'media') {
+                return 'Media';
+            }
+
+            return 'Images';
         }
 
         window.onload = function () {

--- a/manager/media/browser/mcpuk/frmfolders.html
+++ b/manager/media/browser/mcpuk/frmfolders.html
@@ -94,7 +94,8 @@
                 });
 
                 var isRootActive = pathParts.length === 0;
-                var rootNode = this.CreateNode('images', '/', isRootActive);
+                var rootLabel = getResourceTypeLabel(oConnector.ResourceType);
+                var rootNode = this.CreateNode(rootLabel, '/', isRootActive);
                 treeList.appendChild(rootNode.node);
 
                 var parentNode = rootNode;
@@ -168,6 +169,18 @@
         function SetResourceType(type) {
             oConnector.ResourceType = type;
             OpenFolder('/');
+        }
+
+        function getResourceTypeLabel(resourceType) {
+            if (resourceType === 'files') {
+                return 'Files';
+            }
+
+            if (resourceType === 'media') {
+                return 'Media';
+            }
+
+            return 'Images';
         }
 
         window.onload = function () {

--- a/manager/media/browser/mcpuk/frmfolders.html
+++ b/manager/media/browser/mcpuk/frmfolders.html
@@ -154,13 +154,15 @@
 
         function LoadFolders(folderPath) {
             treeManager.Clear();
-            oConnector.CurrentFolder = folderPath;
+            oConnector.CurrentFolder = normalizeFolderPath(folderPath);
             oConnector.SendCommand('GetFolders', null, GetFoldersCallBack);
         }
 
         function GetFoldersCallBack(fckXml) {
             var oNode = fckXml.SelectSingleNode('Connector/CurrentFolder');
-            var sCurrentFolderPath = oNode.attributes.getNamedItem('path').value;
+            var sCurrentFolderPath = normalizeFolderPath(
+                oConnector.CurrentFolder || (oNode && oNode.attributes.getNamedItem('path').value)
+            );
 
             var oNodes = fckXml.SelectNodes('Connector/Folders/Folder');
             treeManager.Render(sCurrentFolderPath, oNodes);
@@ -181,6 +183,20 @@
             }
 
             return 'Images';
+        }
+
+        function normalizeFolderPath(folderPath) {
+            var normalized = folderPath || '/';
+
+            if (normalized.charAt(0) !== '/') {
+                normalized = '/' + normalized;
+            }
+
+            if (normalized.length > 1 && normalized.charAt(normalized.length - 1) !== '/') {
+                normalized += '/';
+            }
+
+            return normalized;
         }
 
         window.onload = function () {


### PR DESCRIPTION
### Motivation
- MCPUK の File Browser で左上のリソース種別を切り替えてもフォルダーツリーの最上位ラベルが常に `Images` のまま表示されていたため、選択中のリソース種別に応じて正しいラベルを表示するようにするための修正です。

### Description
- `manager/media/browser/mcpuk/frmfolders.html` の `Render` 処理でルートラベルをハードコードの `'images'` から `getResourceTypeLabel(oConnector.ResourceType)` に置き換え、`getResourceTypeLabel` ヘルパーを追加して `files`/`media`/`images` に対応する表示名を返すようにしました。

### Testing
- 自動化されたテストは実行しておらず、該当変更に対する自動テストはありません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971f2215cd4832d9fe4d9379472110d)