### PR TITLE
fix(outputfilter): add null coalescing for undefined params keys on P…

### DIFF
--- a/manager/includes/docvars/outputfilter/datagrid.inc.php
+++ b/manager/includes/docvars/outputfilter/datagrid.inc.php
@@ -3,37 +3,37 @@ if (!defined('IN_PARSER_MODE') && !defined('IN_MANAGER_MODE')) exit();
 
 include_once(MODX_CORE_PATH . 'controls/datagrid.class.php');
 $grd = new DataGrid('', $value);
-$grd->noRecordMsg = $params['egmsg'];
+$grd->noRecordMsg = $params['egmsg'] ?? '';
 
-$grd->columnHeaderClass = $params['chdrc'];
-$grd->cssClass = $params['tblc'];
-$grd->itemClass = $params['itmc'];
-$grd->altItemClass = $params['aitmc'];
+$grd->columnHeaderClass = $params['chdrc'] ?? '';
+$grd->cssClass = $params['tblc'] ?? '';
+$grd->itemClass = $params['itmc'] ?? '';
+$grd->altItemClass = $params['aitmc'] ?? '';
 
-$grd->columnHeaderStyle = $params['chdrs'];
-$grd->cssStyle = $params['tbls'];
-$grd->itemStyle = $params['itms'];
-$grd->altItemStyle = $params['aitms'];
+$grd->columnHeaderStyle = $params['chdrs'] ?? '';
+$grd->cssStyle = $params['tbls'] ?? '';
+$grd->itemStyle = $params['itms'] ?? '';
+$grd->altItemStyle = $params['aitms'] ?? '';
 
-$grd->columns = $params['cols'];
-$grd->fields = $params['flds'];
-$grd->colWidths = $params['cwidth'];
-$grd->colAligns = $params['calign'];
-$grd->colColors = $params['ccolor'];
-$grd->colTypes = $params['ctype'];
+$grd->columns = $params['cols'] ?? '';
+$grd->fields = $params['flds'] ?? '';
+$grd->colWidths = $params['cwidth'] ?? '';
+$grd->colAligns = $params['calign'] ?? '';
+$grd->colColors = $params['ccolor'] ?? '';
+$grd->colTypes = $params['ctype'] ?? '';
 
-$grd->cellPadding = $params['cpad'];
-$grd->cellSpacing = $params['cspace'];
-$grd->header = $params['head'];
-$grd->footer = $params['foot'];
-$grd->pageSize = $params['psize'];
-$grd->pagerLocation = $params['ploc'];
-$grd->pagerClass = $params['pclass'];
-$grd->pagerStyle = $params['pstyle'];
+$grd->cellPadding = $params['cpad'] ?? '';
+$grd->cellSpacing = $params['cspace'] ?? '';
+$grd->header = $params['head'] ?? '';
+$grd->footer = $params['foot'] ?? '';
+$grd->pageSize = $params['psize'] ?? '';
+$grd->pagerLocation = $params['ploc'] ?? '';
+$grd->pagerClass = $params['pclass'] ?? '';
+$grd->pagerStyle = $params['pstyle'] ?? '';
 
-$grd->cdelim = $params['cdelim'];
-$grd->cwrap = $params['cwrap'];
-$grd->src_encode = $params['enc'];
-$grd->detectHeader = $params['detecthead'];
+$grd->cdelim = $params['cdelim'] ?? '';
+$grd->cwrap = $params['cwrap'] ?? '';
+$grd->src_encode = $params['enc'] ?? '';
+$grd->detectHeader = $params['detecthead'] ?? '';
 
 return $grd->render();

--- a/manager/includes/docvars/outputfilter/date.inc.php
+++ b/manager/includes/docvars/outputfilter/date.inc.php
@@ -1,11 +1,11 @@
 <?php
 if (!defined('IN_PARSER_MODE') && !defined('IN_MANAGER_MODE')) exit();
 
-if ($value === '' && $params['default'] !== 'Yes') {
+if ($value === '' && ($params['default'] ?? '') !== 'Yes') {
     return '';
 }
 
-$p = $params['dateformat'] ?: $this->toDateFormat(null, 'formatOnly');
+$p = ($params['dateformat'] ?? '') ?: $this->toDateFormat(null, 'formatOnly');
 $timestamp = $this->getUnixtimeFromDateString($value);
 
 if (strpos($p, '%') !== false) {

--- a/manager/includes/docvars/outputfilter/delim.inc.php
+++ b/manager/includes/docvars/outputfilter/delim.inc.php
@@ -2,6 +2,6 @@
 if (!defined('IN_PARSER_MODE') && !defined('IN_MANAGER_MODE')) exit();
 
 $value = $this->parseInput($value, '||');
-$p = $params['delim'] ? $params['delim'] : ',';
+$p = ($params['delim'] ?? '') ?: ',';
 if ($p == "\\n") $p = "\n";
 return str_replace('||', $p, $value);

--- a/manager/includes/docvars/outputfilter/htmltag.inc.php
+++ b/manager/includes/docvars/outputfilter/htmltag.inc.php
@@ -3,32 +3,33 @@ if (!defined('IN_PARSER_MODE') && !defined('IN_MANAGER_MODE')) exit();
 
 $values = $this->parseInput($value, '||', 'array');
 unset($value);
-$tagid = $params['tagid'];
-$tagname = ($params['tagname']) ? $params['tagname'] : 'div';
+$tagid = $params['tagid'] ?? '';
+$tagname = ($params['tagname'] ?? '') ?: 'div';
 // Loop through a list of tags
 $i = 0;
+$o = '';
 foreach ($values as $value) {
     $tagvalue = is_array($value) ? implode(' ', $value) : $value;
     if (!$tagvalue) continue;
 
-    $tagvalue = $this->parseText($params['tagoutput'], ['value' => $tagvalue]);
+    $tagvalue = $this->parseText($params['tagoutput'] ?? '', ['value' => $tagvalue]);
 
-    $attr['id'] = ($tagid ? $tagid : $tagname) . ($i == 0 ? '' : "-{$i}"); // 'tv' already added to id
-    $attr['class'] = $params['tagclass'];
-    $attr['style'] = $params['tagstyle'];
+    $attr['id'] = ($tagid ?: $tagname) . ($i == 0 ? '' : "-{$i}"); // 'tv' already added to id
+    $attr['class'] = $params['tagclass'] ?? '';
+    $attr['style'] = $params['tagstyle'] ?? '';
 
     $_ = [];
     foreach ($attr as $k => $v) {
         if ($v) $_[] = "{$k}=\"{$v}\"";
     }
-    if ($params['tagattrib']) $_[] = $params['tagattrib']; // add extra
+    if ($params['tagattrib'] ?? '') $_[] = $params['tagattrib']; // add extra
     $attributes = implode(' ', $_);
     if ($attributes !== '') $attributes = ' ' . $attributes;
 
     // Output the HTML Tag
     switch ($tagname) {
         case 'img':
-            $o .= "<img src=\"{$tagvalue}\" {$attributes} />\n";
+            $o .= "<img src=\"{$tagvalue}\"{$attributes} />\n";
             break;
         default:
             $o .= "<{$tagname}{$attributes}>{$tagvalue}</{$tagname}>\n";

--- a/manager/includes/docvars/outputfilter/hyperlink.inc.php
+++ b/manager/includes/docvars/outputfilter/hyperlink.inc.php
@@ -2,6 +2,7 @@
 if (!defined('IN_PARSER_MODE') && !defined('IN_MANAGER_MODE')) exit();
 
 $urls = $this->parseInput($value, '||', 'array');
+$o = '';
 foreach ($urls as $url) {
     [$name, $url] = is_array($url) ? $url : explode('==', $url);
     if (!$url) $url = $name;
@@ -11,18 +12,18 @@ foreach ($urls as $url) {
         // setup the link attributes
         $attr = [
             'href' => $url,
-            'title' => $params['title'] ? htmlspecialchars($params['title']) : $name,
-            'class' => $params['linkclass'],
-            'style' => $params['linkstyle'],
-            'target' => $params['target'],
+            'title' => ($params['title'] ?? '') ? htmlspecialchars($params['title']) : $name,
+            'class' => $params['linkclass'] ?? '',
+            'style' => $params['linkstyle'] ?? '',
+            'target' => $params['target'] ?? '',
         ];
         foreach ($attr as $k => $v) {
             $attributes .= ($v ? " {$k}=\"{$v}\"" : '');
         }
-        $attributes .= ' ' . $params['linkattrib']; // add extra
+        $attributes .= ' ' . ($params['linkattrib'] ?? ''); // add extra
 
         // Output the link
-        $o .= '<a' . rtrim($attributes) . '>' . ($params['text'] ? htmlspecialchars($params['text']) : $name) . '</a>';
+        $o .= '<a' . rtrim($attributes) . '>' . (($params['text'] ?? '') ? htmlspecialchars($params['text']) : $name) . '</a>';
     }
 }
 

--- a/manager/includes/docvars/outputfilter/image.inc.php
+++ b/manager/includes/docvars/outputfilter/image.inc.php
@@ -9,13 +9,13 @@ foreach ($images as $image) {
 
     if ($src) {
         // We have a valid source
-        $src = $this->parseText($params['imgoutput'], ['value' => $src]);
+        $src = $this->parseText($params['imgoutput'] ?? '', ['value' => $src]);
         $attr = [
-            'class' => $params['imgclass'],
+            'class' => $params['imgclass'] ?? '',
             'src' => $src,
-            'id' => ($params['id'] ? $params['id'] : ''),
-            'alt' => htmlspecialchars($params['alttext']),
-            'style' => $params['imgstyle']
+            'id' => $params['id'] ?? '',
+            'alt' => htmlspecialchars($params['alttext'] ?? ''),
+            'style' => $params['imgstyle'] ?? ''
         ];
         if (isset($params['align']) && $params['align'] != 'none') {
             $attr['align'] = $params['align'];
@@ -24,7 +24,7 @@ foreach ($images as $image) {
         foreach ($attr as $k => $v) {
             if ($v) $attributes .= " {$k}=\"{$v}\"";
         }
-        $attributes .= ' ' . $params['imgattrib'];
+        $attributes .= ' ' . ($params['imgattrib'] ?? '');
 
         // Output the image with attributes
         $o .= '<img' . rtrim($attributes) . ' />';

--- a/manager/includes/docvars/outputfilter/richtext.inc.php
+++ b/manager/includes/docvars/outputfilter/richtext.inc.php
@@ -2,9 +2,9 @@
 if (!defined('IN_PARSER_MODE') && !defined('IN_MANAGER_MODE')) exit();
 
 $value = $this->parseInput($value);
-$w = $params['w'] ? $params['w'] : '100%';
-$h = $params['h'] ? $params['h'] : '400px';
-$richtexteditor = $params['edt'] ? $params['edt'] : '';
+$w = ($params['w'] ?? '') ?: '100%';
+$h = ($params['h'] ?? '') ?: '400px';
+$richtexteditor = $params['edt'] ?? '';
 $o = '<div class="MODX_RichTextWidget"><textarea id="' . $id . '" name="' . $id . '" style="width:' . $w . '; height:' . $h . ';">';
 $o .= htmlspecialchars($value);
 $o .= '</textarea></div>';

--- a/manager/includes/docvars/outputfilter/string.inc.php
+++ b/manager/includes/docvars/outputfilter/string.inc.php
@@ -2,7 +2,7 @@
 if (!defined('IN_PARSER_MODE') && !defined('IN_MANAGER_MODE')) exit();
 
 $value = $this->parseInput($value);
-$format = strtolower($params['stringformat']);
+$format = strtolower($params['stringformat'] ?? '');
 if ($format == 'zen-han') $o = mb_convert_kana($value, 'as', $this->config['modx_charset']);
 else if ($format == 'han-zen') $o = mb_convert_kana($value, 'AS', $this->config['modx_charset']);
 else if ($format == 'upper case') $o = strtoupper($value);


### PR DESCRIPTION
…HP 8.0+

Fixes "Undefined array key" warnings when outputfilter widget parameters are not explicitly set. Applies to image, hyperlink, htmltag, datagrid, date, delim, string, and richtext outputfilters.

Also initializes $o variable in hyperlink.inc.php and htmltag.inc.php to prevent undefined variable warnings.

Ref forum#10705