### PR TITLE
fix: cast division results to integer for pagination calculations

### DIFF
--- a/manager/actions/report/logging.static.php
+++ b/manager/actions/report/logging.static.php
@@ -288,7 +288,7 @@ $icons_path = manager_style_image_path('icons');
                     // Load up the 2 array in order to display result
                     $array_paging = $p->getPagingArray();
                     $array_row_paging = $p->getPagingRowArray();
-                    $current_row = evo()->input_get('int_cur_position', 0) / $int_num_result;
+                    $current_row = (int)(evo()->input_get('int_cur_position', 0) / $int_num_result);
 
                     // Display the result as you like...
                     echo sprintf('<p>%s %s', lang('paging_showing'), $array_paging['lower']);
@@ -303,11 +303,11 @@ $icons_path = manager_style_image_path('icons');
                     $paging .= $array_paging['previous_link'] . lang('paging_prev') . (isset($array_paging['previous_link']) ? "</a> " : " ");
                     $pagesfound = sizeof($array_row_paging);
                     if ($pagesfound > 6) {
-                        $paging .= $array_row_paging[$current_row - 2];
-                        $paging .= $array_row_paging[$current_row - 1];
-                        $paging .= $array_row_paging[$current_row];
-                        $paging .= $array_row_paging[$current_row + 1];
-                        $paging .= $array_row_paging[$current_row + 2];
+                        $start = max(0, min($current_row - 2, $pagesfound - 5));
+                        $end = min($pagesfound - 1, $start + 4);
+                        for ($i = $start; $i <= $end; $i++) {
+                            $paging .= $array_row_paging[$i];
+                        }
                     } else {
                         for ($i = 0; $i < $pagesfound; $i++) {
                             $paging .= $array_row_paging[$i] . "&nbsp;";

--- a/manager/includes/paginate.inc.php
+++ b/manager/includes/paginate.inc.php
@@ -119,7 +119,7 @@ class Paging
 
     private function getNumberOfPage()
     {
-        return $this->int_nbr_row / $this->int_num_result;
+        return (int)ceil($this->int_nbr_row / $this->int_num_result);
     }
 
     private function getCurrentPage()


### PR DESCRIPTION
This pull request improves the pagination logic in the reporting module to make page calculations more robust and to fix issues with page navigation when there are many pages. The main changes ensure that page numbers are always integers and that the correct range of page links is displayed.

Improvements to pagination calculations:

* Updated the `getNumberOfPage` method in `paginate.inc.php` to always return an integer number of pages using `ceil`, preventing potential issues when the total row count isn't a multiple of the page size.
* Ensured that `$current_row` in `logging.static.php` is always an integer by explicitly casting the result of the division, which avoids errors when accessing the paging array.

Enhancements to page navigation display:

* Refactored the logic for displaying page links when there are more than six pages in `logging.static.php`, so that a continuous block of five page links is shown, starting from the appropriate page and avoiding out-of-bounds errors.