### PR TITLE
feat(agent): プロンプトにAGENTS.mdの確認を追加し、手順を整理

### DIFF
--- a/.codex/skills/review-agent/agents/openai.yaml
+++ b/.codex/skills/review-agent/agents/openai.yaml
@@ -5,7 +5,7 @@ interface:
     `AGENTS.md`、`.agent/agents/reviewer.md`、`.github/codex-pr-rules.md` をこの順で読み、差分をレビューしてください。
 
     進め方:
-    1) `AGENTS.md` を確認する。
+    1) `AGENTS.md`、`.agent/agents/reviewer.md`、`.github/codex-pr-rules.md` をこの順で確認する。
     2) `git diff` と変更ファイルを確認する。
     3) 変更領域に応じて関連する `assets/docs/` と ExecPlan を確認する。
     4) バグ・回帰・セキュリティ・キャッシュ整合性・SSOT違反を優先する。

--- a/.codex/skills/review-agent/agents/openai.yaml
+++ b/.codex/skills/review-agent/agents/openai.yaml
@@ -2,11 +2,12 @@ interface:
   display_name: "Review Agent"
   short_description: "reviewerエージェント定義に沿ってPR差分やローカル差分を日本語レビューする"
   default_prompt: |
-    `.agent/agents/reviewer.md` と `.github/codex-pr-rules.md` を読み、差分をレビューしてください。
+    `AGENTS.md`、`.agent/agents/reviewer.md`、`.github/codex-pr-rules.md` をこの順で読み、差分をレビューしてください。
 
     進め方:
-    1) `git diff` と変更ファイルを確認する。
-    2) 変更領域に応じて関連する `assets/docs/` と ExecPlan を確認する。
-    3) バグ・回帰・セキュリティ・キャッシュ整合性・SSOT違反を優先する。
-    4) 指摘は日本語で、重大度順、ファイル・行番号付きで書く。
-    5) 問題がない場合は明確にそう述べ、残るテストギャップを短く書く。
+    1) `AGENTS.md` を確認する。
+    2) `git diff` と変更ファイルを確認する。
+    3) 変更領域に応じて関連する `assets/docs/` と ExecPlan を確認する。
+    4) バグ・回帰・セキュリティ・キャッシュ整合性・SSOT違反を優先する。
+    5) 指摘は日本語で、重大度順、ファイル・行番号付きで書く。
+    6) 問題がない場合は明確にそう述べ、残るテストギャップを短く書く。


### PR DESCRIPTION
This pull request updates the default review workflow instructions for the "Review Agent" by prioritizing the reading of `AGENTS.md` and clarifying the review steps. These changes help reviewers follow a more structured and comprehensive review process.

**Improvements to review workflow instructions:**

* The default prompt now instructs reviewers to read `AGENTS.md` first, followed by `.agent/agents/reviewer.md` and `.github/codex-pr-rules.md`, ensuring a more thorough understanding of review guidelines.
* The review procedure steps have been updated to explicitly include confirming `AGENTS.md` as the first step and to clarify the order and content of subsequent steps, improving clarity and consistency for reviewers.