### PR TITLE
fix(tmplvars): TVフォーム生成とURL型保存処理をPHP8対応

### DIFF
--- a/assets/modules/docmanager/classes/dm_backend.class.php
+++ b/assets/modules/docmanager/classes/dm_backend.class.php
@@ -184,15 +184,10 @@ class DocManagerBackend
                 $typeSQL = db()->select('*', evo()->getFullTableName('site_tmplvars'), "id=" . $tvKeyName);
                 $row = db()->getRow($typeSQL);
                 if ($row['type'] === 'url') {
-                    $tmplvar = postv("tv" . $row['id']);
-                    $prefix = postv("tv" . $row['id'] . '_prefix', '--');
-                    if ($prefix === 'DocID') {
-                        if (preg_match('/\A[0-9]+\z/', $tmplvar)) {
-                            $tmplvar = '[~' . $tmplvar . '~]';
-                        }
-                    } elseif ($prefix !== '--') {
-                        $tmplvar = $prefix . $tmplvar;
-                    }
+                    $tmplvar = normalize_url_tv_value(
+                        postv("tv" . $row['id']),
+                        postv("tv" . $row['id'] . '_prefix', '--')
+                    );
                 } elseif ($row['type'] === 'file') {
                     $tmplvar = postv("tv" . $row['id']);
                 } else {

--- a/assets/modules/docmanager/classes/dm_backend.class.php
+++ b/assets/modules/docmanager/classes/dm_backend.class.php
@@ -185,12 +185,13 @@ class DocManagerBackend
                 $row = db()->getRow($typeSQL);
                 if ($row['type'] === 'url') {
                     $tmplvar = postv("tv" . $row['id']);
-                    if (postv("tv" . $row['id' . '_prefix']) != '--') {
-                        $tmplvar = str_replace([
-                            "ftp://",
-                            "http://"
-                        ], "", $tmplvar);
-                        $tmplvar = postv("tv" . $row['id' . '_prefix']) . $tmplvar;
+                    $prefix = postv("tv" . $row['id'] . '_prefix', '--');
+                    if ($prefix === 'DocID') {
+                        if (preg_match('/\A[0-9]+\z/', $tmplvar)) {
+                            $tmplvar = '[~' . $tmplvar . '~]';
+                        }
+                    } elseif ($prefix !== '--') {
+                        $tmplvar = $prefix . $tmplvar;
                     }
                 } elseif ($row['type'] === 'file') {
                     $tmplvar = postv("tv" . $row['id']);

--- a/assets/modules/docmanager/templates/main.tpl
+++ b/assets/modules/docmanager/templates/main.tpl
@@ -15,7 +15,6 @@
         jQuery('#workText', parent.mainMenu.document).html('');
         var baseurl = '[+baseurl+]';
         top.mainMenu.defaultTreeFrame();
-        var $j = jQuery.noConflict();
         var lastImageCtrl;
         var lastFileCtrl;
 

--- a/assets/modules/docmanager/templates/main.tpl
+++ b/assets/modules/docmanager/templates/main.tpl
@@ -16,6 +16,43 @@
         var baseurl = '[+baseurl+]';
         top.mainMenu.defaultTreeFrame();
         var $j = jQuery.noConflict();
+        var lastImageCtrl;
+        var lastFileCtrl;
+
+        function OpenServerBrowser(url, width, height) {
+            var left = (screen.width - width) / 2;
+            var top = (screen.height - height) / 2;
+            var options = 'toolbar=no,status=no,resizable=yes,dependent=yes';
+            options += ',width=' + width;
+            options += ',height=' + height;
+            options += ',left=' + left;
+            options += ',top=' + top;
+            window.open(url, 'FCKBrowseWindow', options);
+        }
+
+        function BrowseServer(ctrl) {
+            lastImageCtrl = ctrl;
+            var width = screen.width * 0.7;
+            var height = screen.height * 0.7;
+            OpenServerBrowser(baseurl + 'manager/media/browser/mcpuk/browser.php?Type=images', width, height);
+        }
+
+        function BrowseFileServer(ctrl) {
+            lastFileCtrl = ctrl;
+            var width = screen.width * 0.7;
+            var height = screen.height * 0.7;
+            OpenServerBrowser(baseurl + 'manager/media/browser/mcpuk/browser.php?Type=files', width, height);
+        }
+
+        function SetUrl(url, width, height, alt) {
+            var fieldName = lastFileCtrl || lastImageCtrl;
+            var field = fieldName ? document.templatevariables[fieldName] : null;
+            if (field) {
+                field.value = url;
+            }
+            lastFileCtrl = '';
+            lastImageCtrl = '';
+        }
 
         function loadTemplateVars(tplId) {
             var tokenElement = document.querySelector('meta[name="csrf-token"]');

--- a/assets/modules/docmanager/tv.ajax.php
+++ b/assets/modules/docmanager/tv.ajax.php
@@ -24,22 +24,26 @@ if (!is_numeric(postv('tplID'))) {
     return;
 }
 
-$tplID = postv('tplID');
+$tplID = (int)postv('tplID');
 $rs = db()->select(
-    '*',
-    ["[+prefix+]site_tmplvars tv", "LEFT JOIN [+prefix+]site_tmplvar_templates tvtpl ON tv.id = tvtpl.tmplvarid"],
-    "tvtpl.templateid ='" . $tplID . "'"
+    'tv.*, tvtpl.rank AS template_rank',
+    ["[+prefix+]site_tmplvars tv", "INNER JOIN [+prefix+]site_tmplvar_templates tvtpl ON tv.id = tvtpl.tmplvarid"],
+    "tvtpl.templateid ='" . $tplID . "'",
+    'tvtpl.rank, tv.rank, tv.id'
 );
 $total = db()->count($rs);
 
 header('Content-Type: text/html; charset=' . $modx->config('modx_charset', 'UTF-8'));
 
 if ($total > 0) {
-    require(MODX_CORE_PATH . 'tmplvars.commands.inc.php');
+    require(MODX_CORE_PATH . 'tmplvars.inc.php');
     $output .= "<table class='mutate-tv-table' border='0' cellspacing='0' cellpadding='3'>";
 
     for ($i = 0; $i < $total; $i++) {
         $row = db()->getRow($rs);
+        $defaultText = $row['default_text'] ?? '';
+        $fieldElements = $row['elements'] ?? '';
+        $row['form_name'] = 'templatevariables';
 
         if ($i > 0 && $i < $total) {
             $output .= '<tr><td colspan="2"><div class="split"></div></td></tr>';
@@ -47,17 +51,17 @@ if ($total > 0) {
 
         $output .= '<tr class="mutate-tv-row">
                         <td class="mutate-tv-label">
-                                <label class="mutate-field-title" for="cb_update_tv_' . $row['id'] . '"><input type="checkbox" name="update_tv_' . $row['id'] . '" id="cb_update_tv_' . $row['id'] . '" value="yes" />&nbsp;' . $row['caption'] . '</label><br /><span class="comment">' . $row['description'] . '</span>
+                                <label class="mutate-field-title" for="cb_update_tv_' . $row['id'] . '"><input type="checkbox" name="update_tv_' . $row['id'] . '" id="cb_update_tv_' . $row['id'] . '" value="yes" />&nbsp;' . hsc($row['caption']) . '</label><br /><span class="comment">' . hsc($row['description']) . '</span>
                         </td>
                         <td class="mutate-tv-value">';
-        $base_url = $modx->config('base_url');
         $output .= renderFormElement(
             $row['type'],
             $row['id'],
-            $row['default_text'],
-            $row['elements'],
-            $row['value'],
-            ' style="width:300px;"'
+            $defaultText,
+            $fieldElements,
+            $defaultText,
+            'width:300px;',
+            $row
         );
         $output .= '</td></tr>';
     }
@@ -66,331 +70,3 @@ if ($total > 0) {
     echo $dm->lang['DM_tv_no_tv'];
 }
 echo $output;
-
-
-function renderFormElement($field_type, $field_id, $default_text, $field_elements, $field_value, $field_style = '')
-{
-    global $dm;
-    global $base_url;
-
-    $field_html = '';
-    $field_value = ($field_value != "" ? $field_value : $default_text);
-
-    switch ($field_type) {
-        case 'text': // handler for regular text boxes
-        case 'rawtext': // non-htmlentity converted text boxes
-        case 'email': // handles email input fields
-        case 'number': // handles the input of numbers
-            $field_html .= sprintf(
-                '<input type="text" id="tv%s" name="tv%s" value="%s" %s tvtype="%s" onchange="documentDirty=true;" style="width:100%%" />',
-                $field_id,
-                $field_id,
-                hsc($field_value),
-                $field_style,
-                $field_type
-            );
-            break;
-        case 'textareamini': // handler for textarea mini boxes
-            $field_html .= sprintf(
-                '<textarea id="tv%s" name="tv%s" cols="40" rows="5" onchange="documentDirty=true;" style="width:100%%">%s</textarea>',
-                $field_id,
-                $field_id,
-                hsc($field_value)
-            );
-            break;
-        case 'textarea': // handler for textarea boxes
-        case 'rawtextarea': // non-htmlentity convertex textarea boxes
-        case 'htmlarea': // handler for textarea boxes (deprecated)
-        case "richtext": // handler for textarea boxes
-            $field_html .= sprintf(
-                '<textarea id="tv%s" name="tv%s" cols="40" rows="15" onchange="documentDirty=true;" style="width:100%%;">%s</textarea>',
-                $field_id,
-                $field_id,
-                hsc($field_value)
-            );
-            break;
-        case 'date':
-            $field_id = str_replace(['-', '.'], '_', urldecode($field_id));
-            if ($field_value == '') $field_value = 0;
-            $field_html .= sprintf(
-                '<input id="tv%s" name="tv%s" class="DatePicker" type="text" value="%d" onblur="documentDirty=true;" />',
-                $field_id,
-                $field_id,
-                $field_value == 0 || !isset($field_value) ? '' : $field_value
-            );
-            $field_html .= sprintf(
-                ' <a onclick="document.forms[\'templatevariables\'].elements[\'tv%s\'].value=\'\';document.forms[\'templatevariables\'].elements[\'tv%s\'].onblur(); return true;" onmouseover="window.status=\'clear the date\'; return true;" onmouseout="window.status=\'\'; return true;" style="cursor:pointer; cursor:hand"><img src="media/style/%simages/icons/cal_nodate.gif" width="16" height="16" border="0" alt="No date"></a>',
-                $field_id,
-                $field_id,
-                !empty($dm->theme) ? $dm->theme . "/" : ""
-            );
-
-            break;
-        case 'dropdown': // handler for select boxes
-            $field_html .= sprintf(
-                '<select id="tv%s" name="tv%s" size="1" onchange="documentDirty=true;">',
-                $field_id,
-                $field_id
-            );
-            $index_list = ParseIntputOptions(ProcessTVCommand($field_elements, $field_id));
-            foreach ($index_list as $item => $itemvalue) {
-                [$item, $itemvalue] = (is_array($itemvalue)) ? $itemvalue : explode("==", $itemvalue);
-                if (strlen($itemvalue) == 0) {
-                    $itemvalue = $item;
-                }
-                $field_html .= sprintf(
-                    '<option value="%s"%s>%s</option>',
-                    hsc($itemvalue),
-                    $itemvalue == $field_value ? ' selected="selected"' : '',
-                    hsc($item)
-                );
-            }
-            $field_html .= "</select>";
-            break;
-        case "listbox": // handler for select boxes
-            $field_html .= sprintf(
-                '<select id="tv%s" name="tv%s" onchange="documentDirty=true;" size="8">',
-                $field_id,
-                $field_id
-            );
-            $index_list = ParseIntputOptions(ProcessTVCommand($field_elements, $field_id));
-            foreach ($index_list as $item => $itemvalue) {
-                [$item, $itemvalue] = (is_array($itemvalue)) ? $itemvalue : explode("==", $itemvalue);
-                if (strlen($itemvalue) == 0) {
-                    $itemvalue = $item;
-                }
-                $field_html .= sprintf(
-                    '<option value="%s"%s>%s</option>',
-                    hsc($itemvalue),
-                    $itemvalue == $field_value ? ' selected="selected"' : '', hsc($item)
-                );
-            }
-            $field_html .= "</select>";
-            break;
-        case 'listbox-multiple': // handler for select boxes where you can choose multiple items
-            $field_value = explode('||', $field_value);
-            $field_html .= sprintf(
-                '<select id="tv%s[]" name="tv%s[]" multiple="multiple" onchange="documentDirty=true;" size="8">',
-                $field_id,
-                $field_id
-            );
-            $index_list = ParseIntputOptions(ProcessTVCommand($field_elements, $field_id));
-            foreach ($index_list as $item => $itemvalue) {
-                [$item, $itemvalue] = (is_array($itemvalue)) ? $itemvalue : explode('==', $itemvalue);
-                if (strlen($itemvalue) == 0) {
-                    $itemvalue = $item;
-                }
-                $field_html .= sprintf(
-                    '<option value="%s"%s>%s</option>',
-                    hsc($itemvalue),
-                    in_array($itemvalue, $field_value) ? ' selected="selected"' : '',
-                    hsc($item)
-                );
-            }
-            $field_html .= "</select>";
-            break;
-        case 'url': // handles url input fields
-            $urls = ['' => '--', 'http://' => 'http://', 'https://' => 'https://', 'ftp://' => 'ftp://', 'mailto:' => 'mailto:'];
-            $field_html = sprintf(
-                '<table border="0" cellspacing="0" cellpadding="0"><tr><td><select id="tv%s_prefix" name="tv%s_prefix" onchange="documentDirty=true;">',
-                $field_id,
-                $field_id
-            );
-            foreach ($urls as $k => $v) {
-                if (strpos($field_value, $v) === false) {
-                    $field_html .= sprintf('<option value="%s">%s</option>', $v, $k);
-                } else {
-                    $field_value = str_replace($v, '', $field_value);
-                    $field_html .= sprintf('<option value="%s" selected="selected">%s</option>', $v, $k);
-                }
-            }
-            $field_html .= '</select></td><td>';
-            $field_html .= sprintf(
-                '<input type="text" id="tv%s" name="tv%s" value="%s" width="100" %s onchange="documentDirty=true;" /></td></tr></table>',
-                $field_id,
-                $field_id,
-                hsc($field_value),
-                $field_style
-            );
-            break;
-        case 'checkbox': // handles check boxes
-            $field_value = !is_array($field_value) ? explode('||', $field_value) : $field_value;
-            $index_list = ParseIntputOptions(ProcessTVCommand($field_elements, $field_id));
-            static $i = 0;
-            foreach ($index_list as $item => $itemvalue) {
-                [$item, $itemvalue] = (is_array($itemvalue)) ? $itemvalue : explode("==", $itemvalue);
-                if (strlen($itemvalue) == 0) {
-                    $itemvalue = $item;
-                }
-                $field_html .= sprintf(
-                    '<input type="checkbox" value="%s" id="tv_%d" name="tv%s[]" %s onchange="documentDirty=true;" /><label for="tv_%d">%s</label><br />',
-                    hsc($itemvalue),
-                    $i,
-                    $field_id,
-                    in_array($itemvalue, $field_value) ? " checked='checked'" : "",
-                    $i,
-                    $item
-                );
-                $i++;
-            }
-            break;
-        case 'option': // handles radio buttons
-            $index_list = ParseIntputOptions(ProcessTVCommand($field_elements, $field_id));
-            foreach ($index_list as $item => $itemvalue) {
-                [$item, $itemvalue] = (is_array($itemvalue)) ? $itemvalue : explode("==", $itemvalue);
-                if (strlen($itemvalue) == 0) {
-                    $itemvalue = $item;
-                }
-                $field_html .= '<input type="radio" value="' . hsc($itemvalue) . '" name="tv' . $field_id . '" ' . ($itemvalue == $field_value ? 'checked="checked"' : '') . ' onchange="documentDirty=true;" />' . $item . '<br />';
-            }
-            break;
-        case 'image':    // handles image fields using htmlarea image manager
-            global $ResourceManagerLoaded;
-            global $content, $use_editor, $which_editor;
-            if (!$ResourceManagerLoaded && !(($content['richtext'] == 1 || getv('a') == 4) && $use_editor == 1 && $which_editor == 3)) {
-                $field_html .= "
-				<script type=\"text/javascript\">
-						var lastImageCtrl;
-						var lastFileCtrl;
-						function OpenServerBrowser(url, width, height ) {
-							var iLeft = (screen.width  - width) / 2 ;
-							var iTop  = (screen.height - height) / 2 ;
-
-							var sOptions = 'toolbar=no,status=no,resizable=yes,dependent=yes' ;
-							sOptions += ',width=' + width ;
-							sOptions += ',height=' + height ;
-							sOptions += ',left=' + iLeft ;
-							sOptions += ',top=' + iTop ;
-
-							var oWindow = window.open( url, 'FCKBrowseWindow', sOptions ) ;
-						}
-						function BrowseServer(ctrl) {
-							lastImageCtrl = ctrl;
-							var w = screen.width * 0.7;
-							var h = screen.height * 0.7;
-							OpenServerBrowser('{$base_url}manager/media/browser/mcpuk/browser.php?Type=images', w, h);
-						}
-
-						function BrowseFileServer(ctrl) {
-							lastFileCtrl = ctrl;
-							var w = screen.width * 0.7;
-							var h = screen.height * 0.7;
-							OpenServerBrowser('{$base_url}manager/media/browser/mcpuk/browser.php?Type=files', w, h);
-						}
-
-						function SetUrl(url, width, height, alt){
-							if(lastFileCtrl) {
-								var c = document.templatevariables[lastFileCtrl];
-								if(c) c.value = url;
-								lastFileCtrl = '';
-							} else if(lastImageCtrl) {
-								var c = document.templatevariables[lastImageCtrl];
-								if(c) c.value = url;
-								lastImageCtrl = '';
-							}
-						}
-				</script>";
-                $ResourceManagerLoaded = true;
-            }
-            $field_html .= sprintf(
-                '<input type="text" id="tv%s" name="tv%s"  value="%s" %s onchange="documentDirty=true;" />&nbsp;<input type="button" value="%s" onclick="BrowseServer(\'tv%s\')" />',
-                $field_id,
-                $field_id,
-                $field_value,
-                $field_style,
-                $dm->lang['insert'],
-                $field_id
-            );
-            break;
-        case 'file': // handles the input of file uploads
-            /* Modified by Timon for use with resource browser */
-            global $ResourceManagerLoaded;
-            global $content, $use_editor, $which_editor;
-            if (!$ResourceManagerLoaded && !(($content['richtext'] == 1 || getv('a') == 4) && $use_editor == 1 && $which_editor == 3)) {
-                /* I didn't understand the meaning of the condition above, so I left it untouched ;-) */
-                $field_html .= "
-				<script type=\"text/javascript\">
-						var lastImageCtrl;
-						var lastFileCtrl;
-						function OpenServerBrowser(url, width, height ) {
-							var iLeft = (screen.width  - width) / 2 ;
-							var iTop  = (screen.height - height) / 2 ;
-
-							var sOptions = 'toolbar=no,status=no,resizable=yes,dependent=yes' ;
-							sOptions += ',width=' + width ;
-							sOptions += ',height=' + height ;
-							sOptions += ',left=' + iLeft ;
-							sOptions += ',top=' + iTop ;
-
-							var oWindow = window.open( url, 'FCKBrowseWindow', sOptions ) ;
-						}
-
-							function BrowseServer(ctrl) {
-							lastImageCtrl = ctrl;
-							var w = screen.width * 0.7;
-							var h = screen.height * 0.7;
-							OpenServerBrowser('{$base_url}manager/media/browser/mcpuk/browser.php?Type=images', w, h);
-						}
-
-						function BrowseFileServer(ctrl) {
-							lastFileCtrl = ctrl;
-							var w = screen.width * 0.7;
-							var h = screen.height * 0.7;
-							OpenServerBrowser('{$base_url}manager/media/browser/mcpuk/browser.php?Type=files', w, h);
-						}
-
-						function SetUrl(url, width, height, alt){
-							if(lastFileCtrl) {
-								var c = document.templatevariables[lastFileCtrl];
-								if(c) c.value = url;
-								lastFileCtrl = '';
-							} else if(lastImageCtrl) {
-								var c = document.templatevariables[lastImageCtrl];
-								if(c) c.value = url;
-								lastImageCtrl = '';
-							} else {
-								return;
-							}
-						}
-				</script>";
-                $ResourceManagerLoaded = true;
-            }
-            $field_html .= sprintf(
-                '<input type="text" id="tv%s" name="tv%s"  value="%s" %s onchange="documentDirty=true;" />&nbsp;<input type="button" value="%s" onclick="BrowseFileServer(\'tv%s\')" />',
-                $field_id,
-                $field_id,
-                $field_value,
-                $field_style,
-                $dm->lang['insert'],
-                $field_id
-            );
-
-            break;
-        default: // the default handler -- for errors, mostly
-            $field_html .= sprintf(
-                '<input type="text" id="tv%s" name="tv%s" value="%s" %s onchange="documentDirty=true;" />',
-                $field_id,
-                $field_id,
-                hsc($field_value),
-                $field_style
-            );
-    } // end switch statement
-    return $field_html;
-} // end renderFormElement function
-
-function ParseIntputOptions($v)
-{
-    if (is_array($v)) {
-        return $v;
-    }
-
-    if (!db()->isResult($v)) {
-        return explode('||', $v);
-    }
-
-    $a = [];
-    while ($cols = db()->getRow($v, 'num')) {
-        $a[] = $cols;
-    }
-    return $a;
-}

--- a/assets/plugins/qm/qm.inc.php
+++ b/assets/plugins/qm/qm.inc.php
@@ -431,6 +431,12 @@ class Qm
         if (is_array($tvContent)) {
             $tvContent = implode('||', $tvContent);
         }
+        if ($tvId) {
+            $tvType = db()->getValue(db()->select('type', '[+prefix+]site_tmplvars', "id='{$tvId}'"));
+            if ($tvType === 'url') {
+                $tvContent = normalize_url_tv_value($tvContent, postv('tv' . $tvId . '_prefix', '--'));
+            }
+        }
 
         // Save TV
         if ($tvId) {

--- a/manager/actions/document/mutate_content/fields.php
+++ b/manager/actions/document/mutate_content/fields.php
@@ -334,11 +334,7 @@ function fieldsTV()
                     $tvPBV = implode('||', $form_v[$tvid]);
                     break;
                 case 'url':
-                    if ($form_v[$tvid . '_prefix'] === 'DocID') {
-                        $tvPBV = sprintf('[~%s~]', $form_v[$tvid]);
-                    } else {
-                        $tvPBV = $form_v[$tvid . '_prefix'] . $form_v[$tvid];
-                    }
+                    $tvPBV = normalize_url_tv_value($form_v[$tvid], array_get($form_v, $tvid . '_prefix', '--'));
                     break;
                 default:
                     $tvPBV = $form_v[$tvid];

--- a/manager/actions/element/mutate_module.dynamic.php
+++ b/manager/actions/element/mutate_module.dynamic.php
@@ -623,7 +623,8 @@ function content($key, $default = null)
                         <p><?= $_lang['module_group_access_msg'] ?></p>
                     <?php
                     }
-                    $chk = '';
+                    $chks = '';
+                    $notPublic = false;
                     $rs = db()->select('name, id', '[+prefix+]membergroup_names');
                     $total = db()->count($rs);
                     for ($i = 0; $i < $total; $i++) {

--- a/manager/actions/element/mutate_tmplvars.dynamic.php
+++ b/manager/actions/element/mutate_tmplvars.dynamic.php
@@ -643,7 +643,8 @@ function entity($key, $default = null)
                         </script>
                         <p><?= $_lang['tmplvar_access_msg'] ?></p>
                         <?php
-                        $chk = '';
+                        $chks = '';
+                        $notPublic = false;
                         $rs = db()->select('name, id', '[+prefix+]documentgroup_names');
                         if (empty($groupsarray) && is_array(entity('docgroups')) && empty(entity('id'))) {
                             $groupsarray = entity('docgroups');

--- a/manager/includes/docvars/inputform/form_date.tpl
+++ b/manager/includes/docvars/inputform/form_date.tpl
@@ -1,4 +1,4 @@
 <input data-timepicker="[+timepicker+]" id="[+id+]" name="[+name+]" class="DatePicker" type="text" value="[+value+]"
        style="[+style+]" onblur="documentDirty=true;"/>
-<a onclick="document.forms['mutate'].elements['[+id+]'].value='';document.forms['mutate'].elements['[+id+]'].onblur(); return true;"
+<a onclick="document.forms['[+form_name+]'].elements['[+id+]'].value='';document.forms['[+form_name+]'].elements['[+id+]'].onblur(); return true;"
    style="cursor:pointer; cursor:hand"><img src="[+cal_nodate+]" border="0" alt="No date"></a>

--- a/manager/includes/docvars/inputform/form_file.tpl
+++ b/manager/includes/docvars/inputform/form_file.tpl
@@ -1,2 +1,2 @@
-<input type="text" id="tv%s" name="tv%s" value="%s" %s/>
+<input type="text" id="tv%s" name="tv%s" value="%s" style="%s"/>
 &nbsp;<input type="button" value="%s" onclick="BrowseFileServer('tv%s')"/>

--- a/manager/includes/docvars/inputform/form_image.tpl
+++ b/manager/includes/docvars/inputform/form_image.tpl
@@ -1,2 +1,2 @@
-<input type="text" id="tv%s" name="tv%s" value="%s" %s/>
+<input type="text" id="tv%s" name="tv%s" value="%s" style="%s"/>
 &nbsp;<input type="button" value="%s" onclick="BrowseServer('tv%s')"/>

--- a/manager/includes/docvars/inputform/form_url.tpl
+++ b/manager/includes/docvars/inputform/form_url.tpl
@@ -1,0 +1,12 @@
+<table border="0" cellspacing="0" cellpadding="0">
+    <tr>
+        <td>
+            <select id="[+prefix_id+]" name="[+prefix_name+]">
+                [+options+]
+            </select>
+        </td>
+        <td>
+            <input type="text" id="[+id+]" name="[+name+]" value="[+value+]" style="[+style+]"/>
+        </td>
+    </tr>
+</table>

--- a/manager/includes/helpers.php
+++ b/manager/includes/helpers.php
@@ -290,6 +290,27 @@ function postv($key = null, $default = null)
     return array_get($_POST, $key, $default);
 }
 
+function tv_url_prefixes()
+{
+    return ['--', 'http://', 'https://', 'ftp://', 'mailto:', 'DocID'];
+}
+
+function normalize_url_tv_value($value, $prefix = '--')
+{
+    $value = (string)($value ?? '');
+    $prefix = in_array($prefix, tv_url_prefixes(), true) ? $prefix : '--';
+
+    if ($prefix === 'DocID') {
+        return preg_match('/\A[0-9]+\z/', $value) ? '[~' . $value . '~]' : $value;
+    }
+
+    if ($prefix === '--') {
+        return $value;
+    }
+
+    return $prefix . $value;
+}
+
 function anyv($key = null, $default = null)
 {
     return array_get($_REQUEST, $key, $default);

--- a/manager/includes/helpers.php
+++ b/manager/includes/helpers.php
@@ -308,6 +308,16 @@ function normalize_url_tv_value($value, $prefix = '--')
         return $value;
     }
 
+    foreach (tv_url_prefixes() as $knownPrefix) {
+        if ($knownPrefix === '--' || $knownPrefix === 'DocID') {
+            continue;
+        }
+        if (strpos($value, $knownPrefix) === 0) {
+            $value = substr($value, strlen($knownPrefix));
+            break;
+        }
+    }
+
     return $prefix . $value;
 }
 

--- a/manager/includes/traits/document.parser.subparser.trait.php
+++ b/manager/includes/traits/document.parser.subparser.trait.php
@@ -1524,19 +1524,14 @@ trait DocumentParserSubParserTrait
     private function rendarFormUrl($field_id, $field_value, $field_style)
     {
         $field_value = (string)$field_value;
-        $prefixes = [
-            '--' => '--',
-            'http://' => 'http://',
-            'https://' => 'https://',
-            'ftp://' => 'ftp://',
-            'mailto:' => 'mailto:',
-            'DocID' => 'DocID'
-        ];
+        $prefixes = array_combine(tv_url_prefixes(), tv_url_prefixes());
         $selectedPrefix = '--';
 
         if (preg_match('/^\[~([0-9]+)~\]$/', $field_value, $matches)) {
             $selectedPrefix = 'DocID';
             $field_value = $matches[1];
+        } elseif (strpos($field_value, '--') === 0) {
+            $field_value = substr($field_value, 2);
         } else {
             foreach ($prefixes as $prefix => $label) {
                 if ($prefix === '--' || $prefix === 'DocID') {
@@ -1592,7 +1587,7 @@ trait DocumentParserSubParserTrait
                 ),
                 'name'            => 'tv' . $field_id,
                 'value'           => $field_value ? evo()->hsc($field_value) : '',
-                'style'           => $field_style,
+                'style'           => evo()->hsc($field_style),
                 'tvtype'          => $field_type,
                 'form_name'       => evo()->hsc($formName),
                 'cal_nodate'      => style('icons_cal_nodate'),
@@ -2308,11 +2303,7 @@ trait DocumentParserSubParserTrait
                 $name = $tvname[$k];
                 $prefix_key = "{$k}_prefix";
                 if (isset($input[$prefix_key])) {
-                    if ($input[$prefix_key] !== 'DocID') {
-                        $v = $input[$prefix_key] . $v;
-                    } elseif (preg_match('/\A[0-9]+\z/', $v)) {
-                        $v = '[~' . $v . '~]';
-                    }
+                    $v = normalize_url_tv_value($v, $input[$prefix_key]);
                 }
                 unset($input[$k]);
                 $input[$name] = $v;

--- a/manager/includes/traits/document.parser.subparser.trait.php
+++ b/manager/includes/traits/document.parser.subparser.trait.php
@@ -1379,6 +1379,11 @@ trait DocumentParserSubParserTrait
         global $modx, $content;
 
         $field_type = strtolower($field_type);
+        $default_text = (string)($default_text ?? '');
+        $field_elements = (string)($field_elements ?? '');
+        if ($field_value === null) {
+            $field_value = '';
+        }
 
         if (isset($content['id'])) {
             global $docObject;
@@ -1396,7 +1401,7 @@ trait DocumentParserSubParserTrait
         if (strpos($default_text, '<?php') === 0) {
             $default_text = "@@EVAL:\n" . substr($default_text, 6);
         }
-        if (strpos($field_value, '<?php') === 0) {
+        if (is_string($field_value) && strpos($field_value, '<?php') === 0) {
             $field_value = "@@EVAL:\n" . substr($field_value, 6);
         }
 
@@ -1405,15 +1410,18 @@ trait DocumentParserSubParserTrait
             $field_value = $default_text;
         }
 
-        if (in_array($field_type, ['text', 'rawtext', 'email', 'number', 'zipcode', 'tel', 'url'])) {
+        if (in_array($field_type, ['text', 'rawtext', 'email', 'number', 'zipcode', 'tel'])) {
             return $this->rendarFormText($field_type, $field_id, $field_value, $field_style);
+        }
+        if ($field_type === 'url') {
+            return $this->rendarFormUrl($field_id, $field_value, $field_style);
         }
 
         if (in_array($field_type, ['textarea', 'rawtextarea', 'htmlarea', 'richtext', 'textareamini'])) {
             return $this->rendarFormTextarea($field_type, $field_id, $field_value, $field_style);
         }
         if (in_array($field_type, ['date', 'dateonly'])) {
-            return $this->rendarFormDate($field_type, $field_id, $field_value, $field_style);
+            return $this->rendarFormDate($field_type, $field_id, $field_value, $field_style, $row);
         }
 
         if ($field_type === 'image') {
@@ -1468,11 +1476,11 @@ trait DocumentParserSubParserTrait
         }
 
         return sprintf(
-            '<input type="text" id="tv%s" name="tv%s" value="%s" %s />',
+            '<input type="text" id="tv%s" name="tv%s" value="%s" style="%s" />',
             $field_id,
             $field_id,
             $modx->hsc($field_value),
-            $field_style
+            $modx->hsc($field_style)
         );
     }
 
@@ -1513,12 +1521,68 @@ trait DocumentParserSubParserTrait
         );
     }
 
-    private function rendarFormDate($field_type, $field_id, $field_value, $field_style)
+    private function rendarFormUrl($field_id, $field_value, $field_style)
+    {
+        $field_value = (string)$field_value;
+        $prefixes = [
+            '--' => '--',
+            'http://' => 'http://',
+            'https://' => 'https://',
+            'ftp://' => 'ftp://',
+            'mailto:' => 'mailto:',
+            'DocID' => 'DocID'
+        ];
+        $selectedPrefix = '--';
+
+        if (preg_match('/^\[~([0-9]+)~\]$/', $field_value, $matches)) {
+            $selectedPrefix = 'DocID';
+            $field_value = $matches[1];
+        } else {
+            foreach ($prefixes as $prefix => $label) {
+                if ($prefix === '--' || $prefix === 'DocID') {
+                    continue;
+                }
+                if (strpos($field_value, $prefix) === 0) {
+                    $selectedPrefix = $prefix;
+                    $field_value = substr($field_value, strlen($prefix));
+                    break;
+                }
+            }
+        }
+
+        $options = [];
+        foreach ($prefixes as $prefix => $label) {
+            $options[] = evo()->parseText(
+                '<option value="[+value+]" [+selected+]>[+label+]</option>',
+                [
+                    'value' => evo()->hsc($prefix),
+                    'label' => evo()->hsc($label),
+                    'selected' => $prefix === $selectedPrefix ? 'selected="selected"' : ''
+                ]
+            );
+        }
+
+        return evo()->parseText(
+            file_get_contents(MODX_CORE_PATH . 'docvars/inputform/form_url.tpl'),
+            [
+                'id' => 'tv' . $field_id,
+                'name' => 'tv' . $field_id,
+                'prefix_id' => 'tv' . $field_id . '_prefix',
+                'prefix_name' => 'tv' . $field_id . '_prefix',
+                'options' => implode("\n", $options),
+                'value' => evo()->hsc($field_value),
+                'style' => evo()->hsc($field_style)
+            ]
+        );
+    }
+
+    private function rendarFormDate($field_type, $field_id, $field_value, $field_style, $row = [])
     {
         $format = evo()->config('datetime_format');
         if ($field_type === 'date') {
             $format .= ' hh:mm:00';
         }
+        $formName = isset($row['form_name']) ? $row['form_name'] : 'mutate';
         return evo()->parseText(
             file_get_contents(MODX_CORE_PATH . 'docvars/inputform/form_date.tpl'),
             [
@@ -1530,6 +1594,7 @@ trait DocumentParserSubParserTrait
                 'value'           => $field_value ? evo()->hsc($field_value) : '',
                 'style'           => $field_style,
                 'tvtype'          => $field_type,
+                'form_name'       => evo()->hsc($formName),
                 'cal_nodate'      => style('icons_cal_nodate'),
                 'yearOffset'      => evo()->config('datepicker_offset'),
                 'datetime_format' => $format,
@@ -1639,8 +1704,8 @@ trait DocumentParserSubParserTrait
             file_get_contents(MODX_CORE_PATH . 'docvars/inputform/form_image.tpl'),
             $field_id,
             $field_id,
-            $field_value,
-            $field_style,
+            evo()->hsc($field_value),
+            evo()->hsc($field_style),
             lang('insert'),
             $field_id
         );
@@ -1652,8 +1717,8 @@ trait DocumentParserSubParserTrait
             file_get_contents(MODX_CORE_PATH . 'docvars/inputform/form_file.tpl'),
             $field_id,
             $field_id,
-            $field_value,
-            $field_style,
+            evo()->hsc($field_value),
+            evo()->hsc($field_style),
             lang('insert'),
             $field_id
         );

--- a/manager/processors/document/save_resource.processor.php
+++ b/manager/processors/document/save_resource.processor.php
@@ -195,16 +195,7 @@ function get_tmplvars()
         }
 
         if ($row['type'] === 'url') {
-            if (validated($tvid . '_prefix') === 'DocID') {
-                $value = validated($tvid);
-                if (preg_match('/\A[0-9]+\z/', $value)) {
-                    $value = '[~' . $value . '~]';
-                }
-            } elseif (validated($tvid . '_prefix') !== '--') {
-                $value = validated($tvid . '_prefix') . validated($tvid);
-            } else {
-                $value = validated($tvid);
-            }
+            $value = normalize_url_tv_value(validated($tvid), validated($tvid . '_prefix', '--'));
         } elseif ($row['type'] === 'file') {
             $value = validated($tvid);
         } elseif (is_array(validated($tvid))) {


### PR DESCRIPTION
https://forum.modx.jp/viewtopic.php?t=2036

## 概要

このPRの目的を日本語で記載してください。

This pull request introduces several improvements and refactorings to the handling and rendering of Template Variables (TVs) in the document manager module. The changes focus on modernizing the TV input rendering process by moving HTML markup into template files, enhancing security with better escaping, improving maintainability, and updating the logic for URL TVs. Additionally, there are minor fixes and code cleanups in related areas.

**Key improvements and changes:**

### Template Variable (TV) Rendering Refactor

* Moved the rendering of TV input fields (such as date, file, image, and URL types) from inline PHP string generation to dedicated template files (`form_date.tpl`, `form_file.tpl`, `form_image.tpl`, `form_url.tpl`). This improves maintainability and separation of concerns. [[1]](diffhunk://#diff-8a198ea80305a9efa7484f8659dcda59a447fbe9b4845661e9e4b30a7a99f7f5L69-L396) [[2]](diffhunk://#diff-5b06d38c0a3a71cfb5839fa032a0bc25f9fbab27b8f18add7db654bd20a3e98cL3-R3) [[3]](diffhunk://#diff-1f88d7ea66ff417715737d8894debe465f51424cb28b9e7e4a1b3b161e970064L1-R1) [[4]](diffhunk://#diff-877a519ad3148a312bcc070fed9116a25ebe6e1d65f25c87cd436eacc93b0aeaL1-R1) [[5]](diffhunk://#diff-b746c1fd24c721c156c1cce6fdb73a6383f64fe182b4db24398188477500b7e2R1-R12)
* Updated the `renderFormElement` method to handle null or missing values more robustly and to ensure proper type casting for default text and elements.
* Improved handling of PHP code in TV default values and field values by checking for string type before processing.

### Security and Data Handling

* Added HTML escaping (`hsc()`) for TV captions and descriptions when rendering checkboxes, reducing the risk of XSS vulnerabilities.
* Ensured that TV values are always initialized to a string, preventing potential PHP warnings or errors.

### URL Template Variable Logic Update

* Refined the logic for handling URL TVs: now supports a special "DocID" prefix that wraps numeric values in MODX link notation, and only prepends a prefix if selected (no longer strips protocols unnecessarily).
* Updated the URL TV input to use a template for consistent rendering and easier maintenance.

### JavaScript and UI Improvements

* Moved resource/file/image browser JavaScript functions out of PHP-generated code and into the main template, reducing duplication and improving clarity.

### Minor Fixes and Cleanups

* Fixed variable naming and initialization in access control rendering for modules and TVs. [[1]](diffhunk://#diff-63e4e9385c24f5cbbc03454c09bca502ca9a069bbc25847a3b901ebc83151dfbL626-R627) [[2]](diffhunk://#diff-0d258d130329b11c98e18c9bf77f62d3363ede5b960d6a57a1245c7a86753cbdL646-R647)
* Changed SQL joins and queries in `tv.ajax.php` for more accurate TV listing and ordering.
* Updated form name references in templates to support dynamic forms.

These changes collectively modernize the TV input system, improve security, and lay the groundwork for further enhancements.