### PR TITLE
fix(docmanager,tree): PHP8でのUndefined variable・a=autoによる不正INSERT・ツリーナビゲーション無効化を修正

### DIFF
--- a/assets/modules/docmanager/classes/dm_backend.class.php
+++ b/assets/modules/docmanager/classes/dm_backend.class.php
@@ -162,6 +162,7 @@ class DocManagerBackend
     {
         $tbl_site_tmplvar_contentvalues = evo()->getFullTableName('site_tmplvar_contentvalues');
         $updateError = '';
+        $updated = false;
 
         $results = $this->processRange($pids, 'id', 0);
         $pids = $results[0];

--- a/manager/frames/tree.php
+++ b/manager/frames/tree.php
@@ -206,8 +206,7 @@ if (!sessionv('tree_sortdir')) {
                     alert('<?= $_lang['unable_set_parent'] ?>');
                 }
             }
-            if (ca == "open" || ca == "docinfo" || ca == "doclist" || ca == "") {
-                <?php $action = (!empty(config('tree_page_click')) ? config('tree_page_click') : '27'); ?>
+            if (ca == "open" || ca == "docinfo" || ca == "doclist") {
                 if (id == 0) {
                     // do nothing?
                     parent.main.location.href = "index.php?a=120";
@@ -215,11 +214,8 @@ if (!sessionv('tree_sortdir')) {
                     parent.main.location.href = "index.php?a=3&id=" + id;
                 } else if (ca == "doclist") {
                     parent.main.location.href = "index.php?a=120&id=" + id;
-                } else if (ca == "open") {
-                    parent.main.location.href = "index.php?a=27&id=" + id;
                 } else {
-                    // parent.main.location.href="index.php?a=3&id=" + id + getFolderState(); //just added the getvar &opened=
-                    parent.main.location.href = "index.php?a=<?= $action ?>&id=" + id; // edit as default action
+                    parent.main.location.href = "index.php?a=27&id=" + id;
                 }
             }
             if (ca == "parent") {

--- a/manager/includes/log.class.inc.php
+++ b/manager/includes/log.class.inc.php
@@ -52,7 +52,7 @@ class logHandler
                 'timestamp' => time(),
                 'internalKey' => $this->entry['internalKey'],
                 'username' => $this->entry['username'],
-                'action' => $action_id,
+                'action' => (int)$action_id,
                 'itemid' => $item_id,
                 'itemname' => $this->entry['itemName'],
                 'message' => $this->entry['msg']


### PR DESCRIPTION
## What

フォーラム報告 https://forum.modx.jp/viewtopic.php?p=10756#p10756 で報告された3件のバグを修正する。

## Why

DocManager の「テンプレート変数」タブで「適用」をクリックしたときに発生する PHP8 警告、およびリソースツリーのクリック時に `modx_manager_log` へ不正な値が INSERT される問題を解消するため。

## How

### 1. `Undefined variable $updated` (dm_backend.class.php)
- `changeTemplateVariables()` で `$updated` が未初期化のまま参照されていた
- PHP7 では未定義変数が暗黙的に `null` 扱いされていたため問題が顕在化しなかった
- 関数冒頭に `$updated = false;` を追加して初期化

### 2. `Incorrect integer value: 'auto' for column 'action'` (log.class.inc.php)
- `writeToLog()` で `$action_id` を整数型カラム `action` にそのまま INSERT していた
- `(int)` キャストを追加して防衛的措置とした

### 3. `a=auto` が `manager/index.php` へ送信される根本原因 (tree.php)
- DocManager は `parent.tree.ca = ''` でツリーのナビゲーションを意図的に無効化している
- `tree.php` の `treeAction()` は `ca == ""` のとき `else` 分岐で `a=<?= $action ?>` を送信していた
- `tree_page_click = 'auto'` の環境では `a=auto` という非整数アクションがサーバーへ届き、`modx_manager_log.action`（整数型）への INSERT が失敗していた
- 条件から `ca == ""` を除外し、`ca` が空のときはナビゲーションをスキップするよう修正

## Test

- DocManager の「テンプレート変数」タブでテンプレートを選択し、TV を編集して「適用」→ エラーなく保存できること
- `tree_page_click = 'auto'` 設定でリソースツリーのノードをクリック → 正常に画面遷移し、イベントログにエラーが記録されないこと