### PR TITLE
fix: マネージャー各画面のリクエスト/セッション処理統一・TinyMCE7 CSS対応・bkmanager改善

### DIFF
--- a/assets/plugins/tinymce7/src/TinyMCE7/Editor/EditorInitializer.php
+++ b/assets/plugins/tinymce7/src/TinyMCE7/Editor/EditorInitializer.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace TinyMCE7\Editor;
@@ -96,6 +97,8 @@ final class EditorInitializer
         $config = $this->preferences->applyMenubarPreference($config);
         $config = $this->preferences->applyEnterMode($config);
 
+        $config = $this->applyEditorCssPath($config);
+
         [$config, $fileBrowser] = $this->fileBrowserResolver->resolve($config, $params);
 
         $configJson = $this->configRepository->encode($config);
@@ -147,5 +150,74 @@ final class EditorInitializer
         $output[] = '</script>';
 
         $event->output(implode("\n", $output));
+    }
+
+    private function applyEditorCssPath(array $config): array
+    {
+        if (!function_exists('evo')) {
+            return $config;
+        }
+
+        $editorCssPath = (string)evo()->config('editor_css_path', '');
+        if ($editorCssPath === '') {
+            return $config;
+        }
+
+        if (str_starts_with($editorCssPath, '/') || preg_match('@^https?://@', $editorCssPath)) {
+            $cssUrl = $editorCssPath;
+        } else {
+            $cssUrl = defined('MODX_BASE_URL') ? MODX_BASE_URL . $editorCssPath : '/' . $editorCssPath;
+        }
+
+        $cssUrl = $this->appendEditorCssVersion($cssUrl, $editorCssPath);
+
+        $existing = $config['content_css'] ?? [];
+        if ($existing === false || $existing === '' || $existing === null) {
+            $config['content_css'] = $cssUrl;
+        } elseif (is_array($existing)) {
+            $existing[] = $cssUrl;
+            $config['content_css'] = $existing;
+        } else {
+            $config['content_css'] = [(string)$existing, $cssUrl];
+        }
+
+        return $config;
+    }
+
+    private function appendEditorCssVersion(string $cssUrl, string $editorCssPath): string
+    {
+        if (preg_match('@^https?://@', $editorCssPath)) {
+            return $cssUrl;
+        }
+
+        $queryString = parse_url($cssUrl, PHP_URL_QUERY);
+        if (is_string($queryString)) {
+            parse_str($queryString, $queryParams);
+            if (isset($queryParams['v'])) {
+                return $cssUrl;
+            }
+        }
+
+        $pathPart = parse_url($editorCssPath, PHP_URL_PATH);
+        if (!is_string($pathPart) || $pathPart === '') {
+            $pathPart = $editorCssPath;
+        }
+
+        $localPath = defined('MODX_BASE_PATH')
+            ? MODX_BASE_PATH . ltrim($pathPart, '/')
+            : ltrim($pathPart, '/');
+
+        if (!is_file($localPath)) {
+            return $cssUrl;
+        }
+
+        $mtime = filemtime($localPath);
+        if ($mtime === false) {
+            return $cssUrl;
+        }
+
+        $separator = str_contains($cssUrl, '?') ? '&' : '?';
+
+        return $cssUrl . $separator . 'v=' . $mtime;
     }
 }

--- a/manager/actions/element/mutate_template_tv_rank.dynamic.php
+++ b/manager/actions/element/mutate_template_tv_rank.dynamic.php
@@ -7,21 +7,21 @@ if (!evo()->hasPermission('save_template')) {
     alert()->dumpError();
 }
 
-if (!is_numeric($_REQUEST['id'])) {
+if (!is_numeric(anyv('id'))) {
     echo 'Template ID is NaN';
     exit;
 }
-$id = intval($_REQUEST['id']);
+$id = intval(anyv('id'));
 
 $basePath = $modx->config['base_path'];
 $siteURL = MODX_SITE_URL;
 
 $updateMsg = '';
 
-if (isset($_POST['listSubmitted'])) {
+if (postv('listSubmitted')) {
     $updateMsg .= '<span class="success" id="updated">Updated!<br /><br /></span>';
     foreach ($_POST as $listName => $listValue) {
-        if ($listName === 'listSubmitted') {
+        if ($listName === 'listSubmitted' || $listName === 'csrf_token') {
             continue;
         }
         $orderArray = explode(';', rtrim($listValue, ';'));
@@ -155,5 +155,9 @@ echo '
 </div>
 <form action="" method="post" name="sortableListForm" style="display: none;">
             <input type="hidden" name="listSubmitted" value="true" />
-            <input type="hidden" id="list" name="list" value="" />
+            <input type="hidden" id="list" name="list" value="" />';
+
+echo csrfTokenField();
+
+echo '
 </form>';

--- a/manager/actions/main/welcome.static.php
+++ b/manager/actions/main/welcome.static.php
@@ -46,8 +46,8 @@ $modx->setPlaceholder('info', $_lang['info']);
 // setup message info
 if (evo()->hasPermission('messages')) {
     $messages = manager()->getMessageCount();
-    $_SESSION['nrtotalmessages'] = $messages['total'];
-    $_SESSION['nrnewmessages'] = $messages['new'];
+    sessionv('*nrtotalmessages', $messages['total']);
+    sessionv('*nrnewmessages', $messages['new']);
 
     $msg = '<a href="index.php?a=10"><img src="' . $_style['icons_mail_large'] . '" /></a>
     <span class="inbox-title">&nbsp;' . $_lang["inbox"] . (sessionv('nrnewmessages') > 0 ? " (<span class='message-count-new'>" . sessionv('nrnewmessages') . '</span>)' : '') . '</span><br />';
@@ -194,7 +194,8 @@ if (0 < count($modulemenu)) {
 $modx->setPlaceholder('Modules', $modules);
 
 // do some config checks
-if (config('warning_visibility' == 0 && manager()->isAdmin())
+if (
+    config('warning_visibility' == 0 && manager()->isAdmin())
     || (config('warning_visibility') == 2 && evo()->hasPermission('save_role') == 1)
     || config('warning_visibility') == 1
 ) {

--- a/manager/actions/permission/messages.static.php
+++ b/manager/actions/permission/messages.static.php
@@ -8,25 +8,26 @@ if (!evo()->hasPermission('messages')) {
     alert()->dumpError();
 }
 $icons_path = manager_style_image_path('icons');
-if (isset($_REQUEST['id'])) {
-    $msgid = intval($_REQUEST['id']);
-}
+$msgid = (int) anyv('id', 0);
+$messageMode = (string) anyv('m', '');
+$subjecttext = '';
+$messagetext = '';
 $uid = evo()->getLoginUserID();
 ?>
-    <h1><?= $_lang['messages_title'] ?></h1>
+<h1><?= $_lang['messages_title'] ?></h1>
 <?php
 $location = getv('id') ? '10' : '2';
 ?>
-    <div id="actions">
-        <ul class="actionButtons">
-            <li id="Button5" class="mutate"><a href="#"
-                                               onclick="documentDirty=false;document.location.href='index.php?a=<?= $location ?>';"><img
-                        alt="icons_cancel"
-                        src="<?= $_style["icons_cancel"] ?>"/> <?= $_lang['cancel'] ?></a></li>
-        </ul>
-    </div>
+<div id="actions">
+    <ul class="actionButtons">
+        <li id="Button5" class="mutate"><a href="#"
+                onclick="documentDirty=false;document.location.href='index.php?a=<?= $location ?>';"><img
+                    alt="icons_cancel"
+                    src="<?= $_style["icons_cancel"] ?>" /> <?= $_lang['cancel'] ?></a></li>
+    </ul>
+</div>
 
-<?php if (isset($msgid) && $_REQUEST['m'] == 'r') { ?>
+<?php if ($msgid > 0 && $messageMode === 'r') { ?>
     <div class="section">
         <div class="sectionHeader"><?= $_lang['messages_read_message'] ?></div>
         <div class="sectionBody" id="lyr3">
@@ -52,24 +53,26 @@ $location = getv('id') ? '10' : '2';
                         $row2 = db()->getRow($rs2);
                         $sendername = $row2['username'];
                     }
-                    ?>
+            ?>
                     <table width="600" border="0" cellspacing="0" cellpadding="0">
                         <tr>
                             <td colspan="2">
                                 <ul class="actionButtons">
                                     <li id="btn_reply"><a
                                             href="index.php?a=10&t=c&m=rp&id=<?= $message['id'] ?>"><img
-                                                src="<?= $_style["icons_message_reply"] ?>"/> <?= $_lang['messages_reply'] ?>
+                                                src="<?= $_style["icons_message_reply"] ?>" /> <?= $_lang['messages_reply'] ?>
                                         </a></li>
                                     <li><a href="index.php?a=10&t=c&m=f&id=<?= $message['id'] ?>"><img
-                                                src="<?= $_style["icons_message_forward"] ?>"/> <?= $_lang['messages_forward'] ?>
+                                                src="<?= $_style["icons_message_forward"] ?>" /> <?= $_lang['messages_forward'] ?>
                                         </a></li>
                                     <li><a href="index.php?a=65&id=<?= $message['id'] ?>"><img
-                                                src="<?= $_style["icons_delete_document"] ?>"/> <?= $_lang['delete'] ?>
+                                                src="<?= $_style["icons_delete_document"] ?>" /> <?= $_lang['delete'] ?>
                                         </a></li>
                                     <?php if ($message['sender'] == 0) { ?>
                                         <script
-                                            type="text/javascript">document.getElementById("btn_reply").className = 'disabled';</script>
+                                            type="text/javascript">
+                                            document.getElementById("btn_reply").className = 'disabled';
+                                        </script>
                                     <?php } ?>
                                 </ul>
                             </td>
@@ -104,7 +107,7 @@ $location = getv('id') ? '10' : '2';
                             </td>
                         </tr>
                     </table>
-                    <?php
+            <?php
                     // mark the message as read
                     $rs = db()->update('messageread=1', '[+prefix+]user_messages', "id='{$msgid}'");
                 }
@@ -115,276 +118,280 @@ $location = getv('id') ? '10' : '2';
 <?php } ?>
 
 
-    <div class="section">
-        <div class="sectionHeader"><?= $_lang['messages_inbox'] ?></div>
-        <div class="sectionBody">
-            <?php
+<div class="section">
+    <div class="sectionHeader"><?= $_lang['messages_inbox'] ?></div>
+    <div class="sectionBody">
+        <?php
 
-            // Get  number of rows
-            $rs = db()->select('count(id)', '[+prefix+]user_messages', "recipient='{$uid}'");
-            $num_rows = db()->getValue($rs);
+        // Get  number of rows
+        $rs = db()->select('count(id)', '[+prefix+]user_messages', "recipient='{$uid}'");
+        $num_rows = db()->getValue($rs);
 
-            // ==============================================================
-            // Exemple Usage
-            // Note: I make 2 query to the database for this exemple, it
-            // could (and should) be made with only one query...
-            // ==============================================================
+        // ==============================================================
+        // Exemple Usage
+        // Note: I make 2 query to the database for this exemple, it
+        // could (and should) be made with only one query...
+        // ==============================================================
 
-            // If current position is not set, set it to zero
-            if (!isset($_REQUEST['int_cur_position']) || $_REQUEST['int_cur_position'] == 0) {
-                $int_cur_position = 0;
-            } else {
-                $int_cur_position = $_REQUEST['int_cur_position'];
-            }
+        // If current position is not set, set it to zero
+        $int_cur_position = (int) anyv('int_cur_position', 0);
+        if ($int_cur_position < 0) {
+            $int_cur_position = 0;
+        }
 
-            // Number of result to display on the page, will be in the LIMIT of the sql query also
-            $int_num_result = $modx->config['number_of_messages'];
+        // Number of result to display on the page, will be in the LIMIT of the sql query also
+        $int_num_result = $modx->config['number_of_messages'];
+        $pager = '';
+        $dotablestuff = 0;
 
 
-            $extargv = "&a=10"; // extra argv here (could be anything depending on your page)
+        $extargv = "&a=10"; // extra argv here (could be anything depending on your page)
 
-            include_once(MODX_CORE_PATH . 'paginate.inc.php');
-            // New instance of the Paging class, you can modify the color and the width of the html table
-            $p = new Paging($num_rows, $int_cur_position, $int_num_result, $extargv);
+        include_once(MODX_CORE_PATH . 'paginate.inc.php');
+        // New instance of the Paging class, you can modify the color and the width of the html table
+        $p = new Paging($num_rows, $int_cur_position, $int_num_result, $extargv);
 
-            // Load up the 2 array in order to display result
-            $array_paging = $p->getPagingArray();
-            $array_row_paging = $p->getPagingRowArray();
+        // Load up the 2 array in order to display result
+        $array_paging = $p->getPagingArray();
+        $array_row_paging = $p->getPagingRowArray();
 
-            // Display the result as you like...
-            $pager .= $_lang['showing'] . " " . $array_paging['lower'];
-            $pager .= " " . $_lang['to'] . " " . $array_paging['upper'];
-            $pager .= " (" . $array_paging['total'] . " " . $_lang['total'] . ")";
-            $pager .= "<br />" . $array_paging['previous_link'] . '&lt;&lt;' . (isset($array_paging['previous_link']) ? "</a> " : " ");
-            foreach ($array_row_paging as $v) {
-                $pager .= $v . '&nbsp;';
-            }
-            $pager .= $array_paging['next_link'] . "&gt;&gt;" . (isset($array_paging['next_link']) ? "</a>" : "");
+        // Display the result as you like...
+        $pager .= $_lang['showing'] . " " . $array_paging['lower'];
+        $pager .= " " . $_lang['to'] . " " . $array_paging['upper'];
+        $pager .= " (" . $array_paging['total'] . " " . $_lang['total'] . ")";
+        $pager .= "<br />" . $array_paging['previous_link'] . '&lt;&lt;' . (isset($array_paging['previous_link']) ? "</a> " : " ");
+        foreach ($array_row_paging as $v) {
+            $pager .= $v . '&nbsp;';
+        }
+        $pager .= $array_paging['next_link'] . "&gt;&gt;" . (isset($array_paging['next_link']) ? "</a>" : "");
 
-            $rs = db()->select(
-                '*',
-                '[+prefix+]user_messages',
-                sprintf("recipient='%s'", $uid),
-                'postdate DESC',
-                sprintf('%d, %s', $int_cur_position, $int_num_result)
-            );
-            $limit = db()->count($rs);
-            if ($limit < 1):
-                echo $_lang['messages_no_messages'];
-            else:
+        $rs = db()->select(
+            '*',
+            '[+prefix+]user_messages',
+            sprintf("recipient='%s'", $uid),
+            'postdate DESC',
+            sprintf('%d, %s', $int_cur_position, $int_num_result)
+        );
+        $limit = db()->count($rs);
+        if ($limit < 1):
+            echo $_lang['messages_no_messages'];
+        else:
             echo $pager;
             $dotablestuff = 1;
-            ?>
+        ?>
             <script type="text/javascript" src="media/script/tablesort.js"></script>
             <table border=0 cellpadding=0 cellspacing=0 class="sortabletable sortable-onload-5 rowstyle-even"
-                   id="table-1" width='100%'>
+                id="table-1" width='100%'>
                 <thead>
-                <tr bgcolor='#CCCCCC'>
-                    <th width="12"></th>
-                    <th width="60%" class="sortable"><b><?= $_lang['messages_subject'] ?></b></th>
-                    <th class="sortable"><b><?= $_lang['messages_from'] ?></b></th>
-                    <th class="sortable"><b><?= $_lang['messages_private'] ?></b></th>
-                    <th width="20%" class="sortable"><b><?= $_lang['messages_sent'] ?></b></th>
-                </tr>
+                    <tr bgcolor='#CCCCCC'>
+                        <th width="12"></th>
+                        <th width="60%" class="sortable"><b><?= $_lang['messages_subject'] ?></b></th>
+                        <th class="sortable"><b><?= $_lang['messages_from'] ?></b></th>
+                        <th class="sortable"><b><?= $_lang['messages_private'] ?></b></th>
+                        <th width="20%" class="sortable"><b><?= $_lang['messages_sent'] ?></b></th>
+                    </tr>
                 </thead>
                 <tbody>
-                <?php
-                while ($message = db()->getRow($rs)) :
-                    $message['subject'] = decrypt($message['subject']);
-                    $message['message'] = decrypt($message['message']);
-                    $sender = $message['sender'];
-                    if ($sender == 0):
-                        $sendername = "[System]";
-                    else:
-                        $rs2 = db()->select('username', '[+prefix+]manager_users', "id='{$sender}'");
-                        $row2 = db()->getRow($rs2);
-                        $sendername = $row2['username'];
-                    endif;
-                    $messagestyle = $message['messageread'] == 0 ? "messageUnread" : "messageRead";
+                    <?php
+                    while ($message = db()->getRow($rs)) :
+                        $message['subject'] = decrypt($message['subject']);
+                        $message['message'] = decrypt($message['message']);
+                        $sender = $message['sender'];
+                        if ($sender == 0):
+                            $sendername = "[System]";
+                        else:
+                            $rs2 = db()->select('username', '[+prefix+]manager_users', "id='{$sender}'");
+                            $row2 = db()->getRow($rs2);
+                            $sendername = $row2['username'];
+                        endif;
+                        $messagestyle = $message['messageread'] == 0 ? "messageUnread" : "messageRead";
                     ?>
-                    <tr>
-                        <td><?php if (($message['messageread'] == 0)) {
-                                echo sprintf('<img src="%snew1-09.gif">',
-                                    $icons_path);
-                            } ?></td>
-                        <td class="<?= $messagestyle ?>" style="cursor: pointer; text-decoration: underline;"
-                            onclick="document.location.href='index.php?a=10&id=<?= $message['id'] ?>&m=r';"><?= $message['subject'] ?></td>
-                        <td><?= $sendername ?></td>
-                        <td><?= $message['private'] == 0 ? $_lang['no'] : $_lang['yes'] ?></td>
-                        <td><?= $modx->toDateFormat($message['postdate'] + $modx->config['server_offset_time']) ?></td>
-                    </tr>
-                <?php
-                endwhile;
+                        <tr>
+                            <td><?php if (($message['messageread'] == 0)) {
+                                    echo sprintf(
+                                        '<img src="%snew1-09.gif">',
+                                        $icons_path
+                                    );
+                                } ?></td>
+                            <td class="<?= $messagestyle ?>" style="cursor: pointer; text-decoration: underline;"
+                                onclick="document.location.href='index.php?a=10&id=<?= $message['id'] ?>&m=r';"><?= $message['subject'] ?></td>
+                            <td><?= $sendername ?></td>
+                            <td><?= $message['private'] == 0 ? $_lang['no'] : $_lang['yes'] ?></td>
+                            <td><?= $modx->toDateFormat($message['postdate'] + $modx->config['server_offset_time']) ?></td>
+                        </tr>
+                    <?php
+                    endwhile;
                 endif;
 
                 if ($dotablestuff == 1) { ?>
                 </tbody>
             </table>
         <?php } ?>
-        </div>
     </div>
-    <div class="section">
-        <div class="sectionHeader"><?= $_lang['messages_compose'] ?></div>
-        <div class="sectionBody">
-            <?php
-            if (($_REQUEST['m'] === 'rp' || $_REQUEST['m'] === 'f') && isset($msgid)) {
-                $rs = db()->select('*', '[+prefix+]user_messages', "id='{$msgid}'");
-                $limit = db()->count($rs);
-                if ($limit != 1) {
-                    echo "Wrong number of messages returned!";
+</div>
+<div class="section">
+    <div class="sectionHeader"><?= $_lang['messages_compose'] ?></div>
+    <div class="sectionBody">
+        <?php
+        if (($messageMode === 'rp' || $messageMode === 'f') && $msgid > 0) {
+            $rs = db()->select('*', '[+prefix+]user_messages', "id='{$msgid}'");
+            $limit = db()->count($rs);
+            if ($limit != 1) {
+                echo "Wrong number of messages returned!";
+            } else {
+                $message = db()->getRow($rs);
+                $message['subject'] = decrypt($message['subject']);
+                $message['message'] = decrypt($message['message']);
+                if ($message['recipient'] != $uid) {
+                    echo $_lang['messages_not_allowed_to_read'];
                 } else {
-                    $message = db()->getRow($rs);
-                    $message['subject'] = decrypt($message['subject']);
-                    $message['message'] = decrypt($message['message']);
-                    if ($message['recipient'] != $uid) {
-                        echo $_lang['messages_not_allowed_to_read'];
+                    // output message!
+                    // get the name of the sender
+                    $sender = $message['sender'];
+                    if ($sender == 0) {
+                        $sendername = "[System]";
                     } else {
-                        // output message!
-                        // get the name of the sender
-                        $sender = $message['sender'];
-                        if ($sender == 0) {
-                            $sendername = "[System]";
-                        } else {
-                            $rs2 = db()->select('username', '[+prefix+]manager_users', "id={$sender}");
-                            $row2 = db()->getRow($rs2);
-                            $sendername = $row2['username'];
-                        }
-                        $subjecttext = $_REQUEST['m'] == 'rp' ? "Re: " : "Fwd: ";
-                        $subjecttext .= $message['subject'];
-                        $messagetext = "\n\n\n-----\n" . $_lang['messages_from'] . ": $sendername\n" . $_lang['messages_sent'] . ": " . $modx->toDateFormat($message['postdate'] + $modx->config['server_offset_time']) . "\n" . $_lang['messages_subject'] . ": " . $message['subject'] . "\n\n" . $message['message'];
-                        if ($_REQUEST['m'] == 'rp') {
-                            $recipientindex = $message['sender'];
-                        }
+                        $rs2 = db()->select('username', '[+prefix+]manager_users', "id={$sender}");
+                        $row2 = db()->getRow($rs2);
+                        $sendername = $row2['username'];
+                    }
+                    $subjecttext = $messageMode === 'rp' ? "Re: " : "Fwd: ";
+                    $subjecttext .= $message['subject'];
+                    $messagetext = "\n\n\n-----\n" . $_lang['messages_from'] . ": $sendername\n" . $_lang['messages_sent'] . ": " . $modx->toDateFormat($message['postdate'] + $modx->config['server_offset_time']) . "\n" . $_lang['messages_subject'] . ": " . $message['subject'] . "\n\n" . $message['message'];
+                    if ($messageMode === 'rp') {
+                        $recipientindex = $message['sender'];
                     }
                 }
             }
-            ?>
+        }
+        ?>
 
-            <script type="text/javascript">
-                function hideSpans(showSpan) {
-                    document.getElementById("userspan").style.display = "none";
-                    document.getElementById("groupspan").style.display = "none";
-                    document.getElementById("allspan").style.display = "none";
-                    if (showSpan == 1) {
-                        document.getElementById("userspan").style.display = "block";
-                    }
-                    if (showSpan == 2) {
-                        document.getElementById("groupspan").style.display = "block";
-                    }
-                    if (showSpan == 3) {
-                        document.getElementById("allspan").style.display = "block";
-                    }
+        <script type="text/javascript">
+            function hideSpans(showSpan) {
+                document.getElementById("userspan").style.display = "none";
+                document.getElementById("groupspan").style.display = "none";
+                document.getElementById("allspan").style.display = "none";
+                if (showSpan == 1) {
+                    document.getElementById("userspan").style.display = "block";
                 }
-            </script>
-            <form action="index.php?a=66" method="post" name="messagefrm" enctype="multipart/form-data">
-                <fieldset style="width: 600px;background-color:#fff;border:1px solid #ddd;">
-                    <legend><b><?= $_lang['messages_send_to'] ?>:</b></legend>
-                    <table width="100%" border="0" cellspacing="0" cellpadding="0">
-                        <tr>
-                            <td>
-                                <label><input type=radio name="sendto" VALUE="u" checked
-                                              onClick='hideSpans(1);'><?= $_lang['messages_user'] ?></label>
-                                <label><input type=radio name="sendto" VALUE="g"
-                                              onClick='hideSpans(2);'><?= $_lang['messages_group'] ?></label>
-                                <label><input type=radio name="sendto" VALUE="a"
-                                              onClick='hideSpans(3);'><?= $_lang['messages_all'] ?></label><br/>
-                                <span id='userspan'
-                                      style="display:block;"> <?= $_lang['messages_select_user'] ?>:&nbsp;
-    <?php
-    // get all usernames
-    $rs = db()->select('mu.username,mu.id',
-        '[+prefix+]manager_users mu INNER JOIN [+prefix+]user_attributes mua ON mua.internalkey=mu.id',
-        "mua.blocked='0'");
-    ?>
-    <select name="user" class="inputBox" style="width:150px">
-    <?php
-    while ($row = db()->getRow($rs)) {
-        ?>
-        <option value="<?= $row['id'] ?>"><?= $row['username'] ?></option>
-        <?php
-    }
-    ?>
-    </select>
-</span>
-                                <span id='groupspan'
-                                      style="display:none;"> <?= $_lang['messages_select_group'] ?>:&nbsp;
-    <?php
-    // get all usernames
-    $rs = db()->select('name, id', '[+prefix+]user_roles');
-    ?>
-    <select name="group" class="inputBox" style="width:150px">
-    <?php
-    while ($row = db()->getRow($rs)) {
-        ?>
-        <option value="<?= $row['id'] ?>"><?= $row['name'] ?></option>
-        <?php
-    }
-    ?>
-</select>
-</span>
-                                <span id='allspan' style="display:none;">
-</span>
-                            </td>
-                        </tr>
-                    </table>
-                </fieldset>
+                if (showSpan == 2) {
+                    document.getElementById("groupspan").style.display = "block";
+                }
+                if (showSpan == 3) {
+                    document.getElementById("allspan").style.display = "block";
+                }
+            }
+        </script>
+        <form action="index.php?a=66" method="post" name="messagefrm" enctype="multipart/form-data">
+            <fieldset style="width: 600px;background-color:#fff;border:1px solid #ddd;">
+                <legend><b><?= $_lang['messages_send_to'] ?>:</b></legend>
+                <table width="100%" border="0" cellspacing="0" cellpadding="0">
+                    <tr>
+                        <td>
+                            <label><input type=radio name="sendto" VALUE="u" checked
+                                    onClick='hideSpans(1);'><?= $_lang['messages_user'] ?></label>
+                            <label><input type=radio name="sendto" VALUE="g"
+                                    onClick='hideSpans(2);'><?= $_lang['messages_group'] ?></label>
+                            <label><input type=radio name="sendto" VALUE="a"
+                                    onClick='hideSpans(3);'><?= $_lang['messages_all'] ?></label><br />
+                            <span id='userspan'
+                                style="display:block;"> <?= $_lang['messages_select_user'] ?>:&nbsp;
+                                <?php
+                                // get all usernames
+                                $rs = db()->select(
+                                    'mu.username,mu.id',
+                                    '[+prefix+]manager_users mu INNER JOIN [+prefix+]user_attributes mua ON mua.internalkey=mu.id',
+                                    "mua.blocked='0'"
+                                );
+                                ?>
+                                <select name="user" class="inputBox" style="width:150px">
+                                    <?php
+                                    while ($row = db()->getRow($rs)) {
+                                    ?>
+                                        <option value="<?= $row['id'] ?>"><?= $row['username'] ?></option>
+                                    <?php
+                                    }
+                                    ?>
+                                </select>
+                            </span>
+                            <span id='groupspan'
+                                style="display:none;"> <?= $_lang['messages_select_group'] ?>:&nbsp;
+                                <?php
+                                // get all usernames
+                                $rs = db()->select('name, id', '[+prefix+]user_roles');
+                                ?>
+                                <select name="group" class="inputBox" style="width:150px">
+                                    <?php
+                                    while ($row = db()->getRow($rs)) {
+                                    ?>
+                                        <option value="<?= $row['id'] ?>"><?= $row['name'] ?></option>
+                                    <?php
+                                    }
+                                    ?>
+                                </select>
+                            </span>
+                            <span id='allspan' style="display:none;">
+                            </span>
+                        </td>
+                    </tr>
+                </table>
+            </fieldset>
 
-                <p>
+            <p>
 
-                <fieldset style="width: 600px;background-color:#fff;border:1px solid #ddd;">
-                    <legend><b><?= $_lang['messages_message'] ?>:</b></legend>
+            <fieldset style="width: 600px;background-color:#fff;border:1px solid #ddd;">
+                <legend><b><?= $_lang['messages_message'] ?>:</b></legend>
 
-                    <table width="100%" border="0" cellspacing="0" cellpadding="0">
-                        <tr>
-                            <td><?= $_lang['messages_subject'] ?>:</td>
-                            <td><input name="messagesubject" type=text class="inputBox" style="width: 500px;"
-                                       maxlength="60" value="<?= $subjecttext ?>"></td>
-                        </tr>
-                        <tr>
-                            <td valign="top"><?= $_lang['messages_message'] ?>:</td>
-                            <td><textarea name="messagebody" style="width:500px; height: 200px;" onLoad="this.focus()"
-                                          class="inputBox"><?= $messagetext ?></textarea></td>
-                        </tr>
-                        <tr>
-                            <td></td>
-                            <td>
-                                <ul class="actionButtons" style="margin-top:15px;">
-                                    <li><a href="#" class="primary"
-                                           onclick="documentDirty=false; document.messagefrm.submit();"><img
-                                                src="<?= $_style["icons_save"] ?>"/> <?= $_lang['messages_send'] ?>
-                                        </a></li>
-                                    <li><a href="index.php?a=10&t=c"><img
-                                                src="<?= $_style["icons_cancel"] ?>"/> <?= $_lang['cancel'] ?>
-                                        </a></li>
-                                </ul>
-                            </td>
-                        </tr>
-                    </table>
+                <table width="100%" border="0" cellspacing="0" cellpadding="0">
+                    <tr>
+                        <td><?= $_lang['messages_subject'] ?>:</td>
+                        <td><input name="messagesubject" type=text class="inputBox" style="width: 500px;"
+                                maxlength="60" value="<?= $subjecttext ?>"></td>
+                    </tr>
+                    <tr>
+                        <td valign="top"><?= $_lang['messages_message'] ?>:</td>
+                        <td><textarea name="messagebody" style="width:500px; height: 200px;" onLoad="this.focus()"
+                                class="inputBox"><?= $messagetext ?></textarea></td>
+                    </tr>
+                    <tr>
+                        <td></td>
+                        <td>
+                            <ul class="actionButtons" style="margin-top:15px;">
+                                <li><a href="#" class="primary"
+                                        onclick="documentDirty=false; document.messagefrm.submit();"><img
+                                            src="<?= $_style["icons_save"] ?>" /> <?= $_lang['messages_send'] ?>
+                                    </a></li>
+                                <li><a href="index.php?a=10&t=c"><img
+                                            src="<?= $_style["icons_cancel"] ?>" /> <?= $_lang['cancel'] ?>
+                                    </a></li>
+                            </ul>
+                        </td>
+                    </tr>
+                </table>
 
-                </fieldset>
-            </form>
-        </div>
+            </fieldset>
+        </form>
     </div>
+</div>
 <?php
 // count messages again, as any action on the messages page may have altered the message count
 $rs = db()->select('count(*)', '[+prefix+]user_messages', "recipient='{$uid}' AND messageread=0");
-$_SESSION['nrnewmessages'] = db()->getValue($rs);
+sessionv('*nrnewmessages', db()->getValue($rs));
 $rs = db()->select('count(*)', '[+prefix+]user_messages', "recipient='{$uid}'");
-$_SESSION['nrtotalmessages'] = db()->getValue($rs);
+sessionv('*nrtotalmessages', db()->getValue($rs));
 $messagesallowed = evo()->hasPermission('messages');
 ?>
-    <script type="text/javascript">
-        function msgCountAgain() {
-            try {
-                top.mainMenu.startmsgcount(<?= sessionv('nrnewmessages') ?>,<?= sessionv('nrtotalmessages') ?>,<?= $messagesallowed ? 1 : 0 ?>);
-            } catch (oException) {
-                vv = window.setTimeout('msgCountAgain()', 1500);
-            }
+<script type="text/javascript">
+    function msgCountAgain() {
+        try {
+            top.mainMenu.startmsgcount(<?= sessionv('nrnewmessages') ?>, <?= sessionv('nrtotalmessages') ?>, <?= $messagesallowed ? 1 : 0 ?>);
+        } catch (oException) {
+            vv = window.setTimeout('msgCountAgain()', 1500);
         }
+    }
 
-        v = setTimeout('msgCountAgain()', 1500); // do this with a slight delay so it overwrites msgCount()
-
-    </script>
+    v = setTimeout('msgCountAgain()', 1500); // do this with a slight delay so it overwrites msgCount()
+</script>
 
 <?php
 

--- a/manager/actions/tool/bkmanager.static.php
+++ b/manager/actions/tool/bkmanager.static.php
@@ -195,11 +195,26 @@ if (sessionv('result_msg')) {
                             db()->dbname,
                             db()->table_prefix
                         ));
+                        $truncateable = [
+                            db()->table_prefix . 'event_log',
+                            db()->table_prefix . 'manager_log',
+                        ];
                         $i = 0;
                         $totaloverhead = 0;
                         $total = 0;
                         while ($row = db()->getRow($rs)) {
                             $bgcolor = ($i % 2) ? '#EEEEEE' : '#FFFFFF';
+                            $isTruncateable = in_array($row['Name'], $truncateable, true);
+                            $isInnoDb = strtolower((string)($row['Engine'] ?? '')) === 'innodb';
+                            $recordCount = (int)$row['Rows'];
+                            if ($isTruncateable) {
+                                $recordCount = (int)db()->getValue(
+                                    db()->select(
+                                        'COUNT(*)',
+                                        $row['Name']
+                                    )
+                                );
+                            }
 
                             if (isset($dumper->_dbtables) && !empty($dumper->_dbtables)) {
                                 $table_string = implode(',', $dumper->_dbtables);
@@ -212,26 +227,22 @@ if (sessionv('result_msg')) {
                                     $table_string,
                                     $row['Name']
                                 ) === false ? '' : ' checked="checked"') . ' /><b class="table-name">' . $row['Name'] . '</b></label></td>' . "\n" .
-                                '<td align="right">' . $row['Rows'] . '</td>' . "\n";
+                                '<td align="right">' . (
+                                    evo()->hasPermission('settings') && $isTruncateable && $recordCount > 0
+                                    ? '<a href="index.php?a=54&mode=' . $action . '&u=' . $row['Name'] . '" title="' . $_lang['truncate_table'] . '">' . $recordCount . '</a>'
+                                    : $recordCount
+                                ) . '</td>' . "\n";
                             echo '<td align="right">' . $row['Collation'] . '</td>' . "\n";
 
-                            // Enable record deletion for certain tables (TRUNCATE TABLE) if they're not already empty
-                            $truncateable = [
-                                db()->table_prefix . 'event_log',
-                                db()->table_prefix . 'manager_log',
-                            ];
-                            if (evo()->hasPermission('settings') && in_array(
-                                $row['Name'],
-                                $truncateable
-                            ) && $row['Rows'] > 0) {
-                                echo '<td dir="ltr" align="right">' .
-                                    '<a href="index.php?a=54&mode=' . $action . '&u=' . $row['Name'] . '" title="' . $_lang['truncate_table'] . '">' . evo()->nicesize($row['Data_length'] + $row['Data_free']) . '</a>' .
-                                    '</td>' . "\n";
+                            if ($isInnoDb) {
+                                echo '<td dir="ltr" align="right">-</td>' . "\n";
                             } else {
                                 echo '<td dir="ltr" align="right">' . evo()->nicesize($row['Data_length'] + $row['Data_free']) . '</td>' . "\n";
                             }
 
-                            if (evo()->hasPermission('settings')) {
+                            if ($isInnoDb) {
+                                echo '<td align="right">-</td>' . "\n";
+                            } elseif (evo()->hasPermission('settings')) {
                                 echo '<td align="right">' . ($row['Data_free'] > 0 ?
                                     '<a href="index.php?a=54&mode=' . $action . '&t=' . $row['Name'] . '" title="' . $_lang['optimize_table'] . '">' . evo()->nicesize($row['Data_free']) . '</a>' :
                                     '-') .


### PR DESCRIPTION
## Summary

- **TinyMCE7**: `editor_css_path` 設定値をエディタの `content_css` に適用する機能を追加。絶対URL・相対パス・外部URLを正規化し、ローカルファイルの mtime をクエリパラメータとしてキャッシュバスティングを実装
- **messages.static**: `$_REQUEST` 直参照を `anyv()` / `sessionv()` ヘルパーに統一。インデントを全面的に整理し可読性を向上
- **welcome.static**: `$_SESSION` 直代入を `sessionv('*key', value)` に統一。メッセージカウント取得も合わせて修正
- **template-tv-rank**: `$_REQUEST['id']` を `anyv('id')` に、`isset($_POST['listSubmitted'])` を `postv()` に修正。フォームに CSRF トークンフィールドを追加
- **bkmanager**: `truncateable` 配列をループ外に移動。InnoDB テーブルの行数を `COUNT(*)` で正確に取得し、オーバーヘッド/フリースペースカラムに `-` を表示するよう調整

## Test plan

- [ ] TinyMCE7 エディタで `editor_css_path` 設定時にカスタム CSS が読み込まれること
- [ ] メッセージ一覧・送受信・返信・転送が正常に動作すること
- [ ] ウェルカム画面でメッセージカウントが正しく表示されること
- [ ] テンプレートTV並び替え画面で ID 取得・CSRF 検証が正常に動作すること
- [ ] バックアップマネージャーでテーブル一覧が正しく表示され、トランケートリンクが機能すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)