### PR TITLE
fix(tmplvars): TVフォーム生成とURL型保存処理をPHP8対応

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,11 @@
+language: "ja-JP"
+
+reviews:
+    profile: "assertive"
+    high_level_summary: true
+    review_status: true
+    poem: false
+    collapse_walkthrough: true
+
+chat:
+    auto_reply: true

--- a/assets/modules/docmanager/classes/dm_backend.class.php
+++ b/assets/modules/docmanager/classes/dm_backend.class.php
@@ -185,14 +185,10 @@ class DocManagerBackend
                 $typeSQL = db()->select('*', evo()->getFullTableName('site_tmplvars'), "id=" . $tvKeyName);
                 $row = db()->getRow($typeSQL);
                 if ($row['type'] === 'url') {
-                    $tmplvar = postv("tv" . $row['id']);
-                    if (postv("tv" . $row['id' . '_prefix']) != '--') {
-                        $tmplvar = str_replace([
-                            "ftp://",
-                            "http://"
-                        ], "", $tmplvar);
-                        $tmplvar = postv("tv" . $row['id' . '_prefix']) . $tmplvar;
-                    }
+                    $tmplvar = normalize_url_tv_value(
+                        postv("tv" . $row['id']),
+                        postv("tv" . $row['id'] . '_prefix', '--')
+                    );
                 } elseif ($row['type'] === 'file') {
                     $tmplvar = postv("tv" . $row['id']);
                 } else {

--- a/assets/modules/docmanager/templates/main.tpl
+++ b/assets/modules/docmanager/templates/main.tpl
@@ -15,7 +15,43 @@
         jQuery('#workText', parent.mainMenu.document).html('');
         var baseurl = '[+baseurl+]';
         top.mainMenu.defaultTreeFrame();
-        var $j = jQuery.noConflict();
+        var lastImageCtrl;
+        var lastFileCtrl;
+
+        function OpenServerBrowser(url, width, height) {
+            var left = (screen.width - width) / 2;
+            var top = (screen.height - height) / 2;
+            var options = 'toolbar=no,status=no,resizable=yes,dependent=yes';
+            options += ',width=' + width;
+            options += ',height=' + height;
+            options += ',left=' + left;
+            options += ',top=' + top;
+            window.open(url, 'FCKBrowseWindow', options);
+        }
+
+        function BrowseServer(ctrl) {
+            lastImageCtrl = ctrl;
+            var width = screen.width * 0.7;
+            var height = screen.height * 0.7;
+            OpenServerBrowser(baseurl + 'manager/media/browser/mcpuk/browser.php?Type=images', width, height);
+        }
+
+        function BrowseFileServer(ctrl) {
+            lastFileCtrl = ctrl;
+            var width = screen.width * 0.7;
+            var height = screen.height * 0.7;
+            OpenServerBrowser(baseurl + 'manager/media/browser/mcpuk/browser.php?Type=files', width, height);
+        }
+
+        function SetUrl(url, width, height, alt) {
+            var fieldName = lastFileCtrl || lastImageCtrl;
+            var field = fieldName ? document.templatevariables[fieldName] : null;
+            if (field) {
+                field.value = url;
+            }
+            lastFileCtrl = '';
+            lastImageCtrl = '';
+        }
 
         function loadTemplateVars(tplId) {
             var tokenElement = document.querySelector('meta[name="csrf-token"]');

--- a/assets/modules/docmanager/tv.ajax.php
+++ b/assets/modules/docmanager/tv.ajax.php
@@ -24,22 +24,26 @@ if (!is_numeric(postv('tplID'))) {
     return;
 }
 
-$tplID = postv('tplID');
+$tplID = (int)postv('tplID');
 $rs = db()->select(
-    '*',
-    ["[+prefix+]site_tmplvars tv", "LEFT JOIN [+prefix+]site_tmplvar_templates tvtpl ON tv.id = tvtpl.tmplvarid"],
-    "tvtpl.templateid ='" . $tplID . "'"
+    'tv.*, tvtpl.rank AS template_rank',
+    ["[+prefix+]site_tmplvars tv", "INNER JOIN [+prefix+]site_tmplvar_templates tvtpl ON tv.id = tvtpl.tmplvarid"],
+    "tvtpl.templateid ='" . $tplID . "'",
+    'tvtpl.rank, tv.rank, tv.id'
 );
 $total = db()->count($rs);
 
 header('Content-Type: text/html; charset=' . $modx->config('modx_charset', 'UTF-8'));
 
 if ($total > 0) {
-    require(MODX_CORE_PATH . 'tmplvars.commands.inc.php');
+    require(MODX_CORE_PATH . 'tmplvars.inc.php');
     $output .= "<table class='mutate-tv-table' border='0' cellspacing='0' cellpadding='3'>";
 
     for ($i = 0; $i < $total; $i++) {
         $row = db()->getRow($rs);
+        $defaultText = $row['default_text'] ?? '';
+        $fieldElements = $row['elements'] ?? '';
+        $row['form_name'] = 'templatevariables';
 
         if ($i > 0 && $i < $total) {
             $output .= '<tr><td colspan="2"><div class="split"></div></td></tr>';
@@ -47,17 +51,17 @@ if ($total > 0) {
 
         $output .= '<tr class="mutate-tv-row">
                         <td class="mutate-tv-label">
-                                <label class="mutate-field-title" for="cb_update_tv_' . $row['id'] . '"><input type="checkbox" name="update_tv_' . $row['id'] . '" id="cb_update_tv_' . $row['id'] . '" value="yes" />&nbsp;' . $row['caption'] . '</label><br /><span class="comment">' . $row['description'] . '</span>
+                                <label class="mutate-field-title" for="cb_update_tv_' . $row['id'] . '"><input type="checkbox" name="update_tv_' . $row['id'] . '" id="cb_update_tv_' . $row['id'] . '" value="yes" />&nbsp;' . hsc($row['caption']) . '</label><br /><span class="comment">' . hsc($row['description']) . '</span>
                         </td>
                         <td class="mutate-tv-value">';
-        $base_url = $modx->config('base_url');
         $output .= renderFormElement(
             $row['type'],
             $row['id'],
-            $row['default_text'],
-            $row['elements'],
-            $row['value'],
-            ' style="width:300px;"'
+            $defaultText,
+            $fieldElements,
+            $defaultText,
+            'width:300px;',
+            $row
         );
         $output .= '</td></tr>';
     }
@@ -66,331 +70,3 @@ if ($total > 0) {
     echo $dm->lang['DM_tv_no_tv'];
 }
 echo $output;
-
-
-function renderFormElement($field_type, $field_id, $default_text, $field_elements, $field_value, $field_style = '')
-{
-    global $dm;
-    global $base_url;
-
-    $field_html = '';
-    $field_value = ($field_value != "" ? $field_value : $default_text);
-
-    switch ($field_type) {
-        case 'text': // handler for regular text boxes
-        case 'rawtext': // non-htmlentity converted text boxes
-        case 'email': // handles email input fields
-        case 'number': // handles the input of numbers
-            $field_html .= sprintf(
-                '<input type="text" id="tv%s" name="tv%s" value="%s" %s tvtype="%s" onchange="documentDirty=true;" style="width:100%%" />',
-                $field_id,
-                $field_id,
-                hsc($field_value),
-                $field_style,
-                $field_type
-            );
-            break;
-        case 'textareamini': // handler for textarea mini boxes
-            $field_html .= sprintf(
-                '<textarea id="tv%s" name="tv%s" cols="40" rows="5" onchange="documentDirty=true;" style="width:100%%">%s</textarea>',
-                $field_id,
-                $field_id,
-                hsc($field_value)
-            );
-            break;
-        case 'textarea': // handler for textarea boxes
-        case 'rawtextarea': // non-htmlentity convertex textarea boxes
-        case 'htmlarea': // handler for textarea boxes (deprecated)
-        case "richtext": // handler for textarea boxes
-            $field_html .= sprintf(
-                '<textarea id="tv%s" name="tv%s" cols="40" rows="15" onchange="documentDirty=true;" style="width:100%%;">%s</textarea>',
-                $field_id,
-                $field_id,
-                hsc($field_value)
-            );
-            break;
-        case 'date':
-            $field_id = str_replace(['-', '.'], '_', urldecode($field_id));
-            if ($field_value == '') $field_value = 0;
-            $field_html .= sprintf(
-                '<input id="tv%s" name="tv%s" class="DatePicker" type="text" value="%d" onblur="documentDirty=true;" />',
-                $field_id,
-                $field_id,
-                $field_value == 0 || !isset($field_value) ? '' : $field_value
-            );
-            $field_html .= sprintf(
-                ' <a onclick="document.forms[\'templatevariables\'].elements[\'tv%s\'].value=\'\';document.forms[\'templatevariables\'].elements[\'tv%s\'].onblur(); return true;" onmouseover="window.status=\'clear the date\'; return true;" onmouseout="window.status=\'\'; return true;" style="cursor:pointer; cursor:hand"><img src="media/style/%simages/icons/cal_nodate.gif" width="16" height="16" border="0" alt="No date"></a>',
-                $field_id,
-                $field_id,
-                !empty($dm->theme) ? $dm->theme . "/" : ""
-            );
-
-            break;
-        case 'dropdown': // handler for select boxes
-            $field_html .= sprintf(
-                '<select id="tv%s" name="tv%s" size="1" onchange="documentDirty=true;">',
-                $field_id,
-                $field_id
-            );
-            $index_list = ParseIntputOptions(ProcessTVCommand($field_elements, $field_id));
-            foreach ($index_list as $item => $itemvalue) {
-                [$item, $itemvalue] = (is_array($itemvalue)) ? $itemvalue : explode("==", $itemvalue);
-                if (strlen($itemvalue) == 0) {
-                    $itemvalue = $item;
-                }
-                $field_html .= sprintf(
-                    '<option value="%s"%s>%s</option>',
-                    hsc($itemvalue),
-                    $itemvalue == $field_value ? ' selected="selected"' : '',
-                    hsc($item)
-                );
-            }
-            $field_html .= "</select>";
-            break;
-        case "listbox": // handler for select boxes
-            $field_html .= sprintf(
-                '<select id="tv%s" name="tv%s" onchange="documentDirty=true;" size="8">',
-                $field_id,
-                $field_id
-            );
-            $index_list = ParseIntputOptions(ProcessTVCommand($field_elements, $field_id));
-            foreach ($index_list as $item => $itemvalue) {
-                [$item, $itemvalue] = (is_array($itemvalue)) ? $itemvalue : explode("==", $itemvalue);
-                if (strlen($itemvalue) == 0) {
-                    $itemvalue = $item;
-                }
-                $field_html .= sprintf(
-                    '<option value="%s"%s>%s</option>',
-                    hsc($itemvalue),
-                    $itemvalue == $field_value ? ' selected="selected"' : '', hsc($item)
-                );
-            }
-            $field_html .= "</select>";
-            break;
-        case 'listbox-multiple': // handler for select boxes where you can choose multiple items
-            $field_value = explode('||', $field_value);
-            $field_html .= sprintf(
-                '<select id="tv%s[]" name="tv%s[]" multiple="multiple" onchange="documentDirty=true;" size="8">',
-                $field_id,
-                $field_id
-            );
-            $index_list = ParseIntputOptions(ProcessTVCommand($field_elements, $field_id));
-            foreach ($index_list as $item => $itemvalue) {
-                [$item, $itemvalue] = (is_array($itemvalue)) ? $itemvalue : explode('==', $itemvalue);
-                if (strlen($itemvalue) == 0) {
-                    $itemvalue = $item;
-                }
-                $field_html .= sprintf(
-                    '<option value="%s"%s>%s</option>',
-                    hsc($itemvalue),
-                    in_array($itemvalue, $field_value) ? ' selected="selected"' : '',
-                    hsc($item)
-                );
-            }
-            $field_html .= "</select>";
-            break;
-        case 'url': // handles url input fields
-            $urls = ['' => '--', 'http://' => 'http://', 'https://' => 'https://', 'ftp://' => 'ftp://', 'mailto:' => 'mailto:'];
-            $field_html = sprintf(
-                '<table border="0" cellspacing="0" cellpadding="0"><tr><td><select id="tv%s_prefix" name="tv%s_prefix" onchange="documentDirty=true;">',
-                $field_id,
-                $field_id
-            );
-            foreach ($urls as $k => $v) {
-                if (strpos($field_value, $v) === false) {
-                    $field_html .= sprintf('<option value="%s">%s</option>', $v, $k);
-                } else {
-                    $field_value = str_replace($v, '', $field_value);
-                    $field_html .= sprintf('<option value="%s" selected="selected">%s</option>', $v, $k);
-                }
-            }
-            $field_html .= '</select></td><td>';
-            $field_html .= sprintf(
-                '<input type="text" id="tv%s" name="tv%s" value="%s" width="100" %s onchange="documentDirty=true;" /></td></tr></table>',
-                $field_id,
-                $field_id,
-                hsc($field_value),
-                $field_style
-            );
-            break;
-        case 'checkbox': // handles check boxes
-            $field_value = !is_array($field_value) ? explode('||', $field_value) : $field_value;
-            $index_list = ParseIntputOptions(ProcessTVCommand($field_elements, $field_id));
-            static $i = 0;
-            foreach ($index_list as $item => $itemvalue) {
-                [$item, $itemvalue] = (is_array($itemvalue)) ? $itemvalue : explode("==", $itemvalue);
-                if (strlen($itemvalue) == 0) {
-                    $itemvalue = $item;
-                }
-                $field_html .= sprintf(
-                    '<input type="checkbox" value="%s" id="tv_%d" name="tv%s[]" %s onchange="documentDirty=true;" /><label for="tv_%d">%s</label><br />',
-                    hsc($itemvalue),
-                    $i,
-                    $field_id,
-                    in_array($itemvalue, $field_value) ? " checked='checked'" : "",
-                    $i,
-                    $item
-                );
-                $i++;
-            }
-            break;
-        case 'option': // handles radio buttons
-            $index_list = ParseIntputOptions(ProcessTVCommand($field_elements, $field_id));
-            foreach ($index_list as $item => $itemvalue) {
-                [$item, $itemvalue] = (is_array($itemvalue)) ? $itemvalue : explode("==", $itemvalue);
-                if (strlen($itemvalue) == 0) {
-                    $itemvalue = $item;
-                }
-                $field_html .= '<input type="radio" value="' . hsc($itemvalue) . '" name="tv' . $field_id . '" ' . ($itemvalue == $field_value ? 'checked="checked"' : '') . ' onchange="documentDirty=true;" />' . $item . '<br />';
-            }
-            break;
-        case 'image':    // handles image fields using htmlarea image manager
-            global $ResourceManagerLoaded;
-            global $content, $use_editor, $which_editor;
-            if (!$ResourceManagerLoaded && !(($content['richtext'] == 1 || getv('a') == 4) && $use_editor == 1 && $which_editor == 3)) {
-                $field_html .= "
-				<script type=\"text/javascript\">
-						var lastImageCtrl;
-						var lastFileCtrl;
-						function OpenServerBrowser(url, width, height ) {
-							var iLeft = (screen.width  - width) / 2 ;
-							var iTop  = (screen.height - height) / 2 ;
-
-							var sOptions = 'toolbar=no,status=no,resizable=yes,dependent=yes' ;
-							sOptions += ',width=' + width ;
-							sOptions += ',height=' + height ;
-							sOptions += ',left=' + iLeft ;
-							sOptions += ',top=' + iTop ;
-
-							var oWindow = window.open( url, 'FCKBrowseWindow', sOptions ) ;
-						}
-						function BrowseServer(ctrl) {
-							lastImageCtrl = ctrl;
-							var w = screen.width * 0.7;
-							var h = screen.height * 0.7;
-							OpenServerBrowser('{$base_url}manager/media/browser/mcpuk/browser.php?Type=images', w, h);
-						}
-
-						function BrowseFileServer(ctrl) {
-							lastFileCtrl = ctrl;
-							var w = screen.width * 0.7;
-							var h = screen.height * 0.7;
-							OpenServerBrowser('{$base_url}manager/media/browser/mcpuk/browser.php?Type=files', w, h);
-						}
-
-						function SetUrl(url, width, height, alt){
-							if(lastFileCtrl) {
-								var c = document.templatevariables[lastFileCtrl];
-								if(c) c.value = url;
-								lastFileCtrl = '';
-							} else if(lastImageCtrl) {
-								var c = document.templatevariables[lastImageCtrl];
-								if(c) c.value = url;
-								lastImageCtrl = '';
-							}
-						}
-				</script>";
-                $ResourceManagerLoaded = true;
-            }
-            $field_html .= sprintf(
-                '<input type="text" id="tv%s" name="tv%s"  value="%s" %s onchange="documentDirty=true;" />&nbsp;<input type="button" value="%s" onclick="BrowseServer(\'tv%s\')" />',
-                $field_id,
-                $field_id,
-                $field_value,
-                $field_style,
-                $dm->lang['insert'],
-                $field_id
-            );
-            break;
-        case 'file': // handles the input of file uploads
-            /* Modified by Timon for use with resource browser */
-            global $ResourceManagerLoaded;
-            global $content, $use_editor, $which_editor;
-            if (!$ResourceManagerLoaded && !(($content['richtext'] == 1 || getv('a') == 4) && $use_editor == 1 && $which_editor == 3)) {
-                /* I didn't understand the meaning of the condition above, so I left it untouched ;-) */
-                $field_html .= "
-				<script type=\"text/javascript\">
-						var lastImageCtrl;
-						var lastFileCtrl;
-						function OpenServerBrowser(url, width, height ) {
-							var iLeft = (screen.width  - width) / 2 ;
-							var iTop  = (screen.height - height) / 2 ;
-
-							var sOptions = 'toolbar=no,status=no,resizable=yes,dependent=yes' ;
-							sOptions += ',width=' + width ;
-							sOptions += ',height=' + height ;
-							sOptions += ',left=' + iLeft ;
-							sOptions += ',top=' + iTop ;
-
-							var oWindow = window.open( url, 'FCKBrowseWindow', sOptions ) ;
-						}
-
-							function BrowseServer(ctrl) {
-							lastImageCtrl = ctrl;
-							var w = screen.width * 0.7;
-							var h = screen.height * 0.7;
-							OpenServerBrowser('{$base_url}manager/media/browser/mcpuk/browser.php?Type=images', w, h);
-						}
-
-						function BrowseFileServer(ctrl) {
-							lastFileCtrl = ctrl;
-							var w = screen.width * 0.7;
-							var h = screen.height * 0.7;
-							OpenServerBrowser('{$base_url}manager/media/browser/mcpuk/browser.php?Type=files', w, h);
-						}
-
-						function SetUrl(url, width, height, alt){
-							if(lastFileCtrl) {
-								var c = document.templatevariables[lastFileCtrl];
-								if(c) c.value = url;
-								lastFileCtrl = '';
-							} else if(lastImageCtrl) {
-								var c = document.templatevariables[lastImageCtrl];
-								if(c) c.value = url;
-								lastImageCtrl = '';
-							} else {
-								return;
-							}
-						}
-				</script>";
-                $ResourceManagerLoaded = true;
-            }
-            $field_html .= sprintf(
-                '<input type="text" id="tv%s" name="tv%s"  value="%s" %s onchange="documentDirty=true;" />&nbsp;<input type="button" value="%s" onclick="BrowseFileServer(\'tv%s\')" />',
-                $field_id,
-                $field_id,
-                $field_value,
-                $field_style,
-                $dm->lang['insert'],
-                $field_id
-            );
-
-            break;
-        default: // the default handler -- for errors, mostly
-            $field_html .= sprintf(
-                '<input type="text" id="tv%s" name="tv%s" value="%s" %s onchange="documentDirty=true;" />',
-                $field_id,
-                $field_id,
-                hsc($field_value),
-                $field_style
-            );
-    } // end switch statement
-    return $field_html;
-} // end renderFormElement function
-
-function ParseIntputOptions($v)
-{
-    if (is_array($v)) {
-        return $v;
-    }
-
-    if (!db()->isResult($v)) {
-        return explode('||', $v);
-    }
-
-    $a = [];
-    while ($cols = db()->getRow($v, 'num')) {
-        $a[] = $cols;
-    }
-    return $a;
-}

--- a/assets/plugins/qm/qm.inc.php
+++ b/assets/plugins/qm/qm.inc.php
@@ -431,6 +431,12 @@ class Qm
         if (is_array($tvContent)) {
             $tvContent = implode('||', $tvContent);
         }
+        if ($tvId) {
+            $tvType = db()->getValue(db()->select('type', '[+prefix+]site_tmplvars', "id='{$tvId}'"));
+            if ($tvType === 'url') {
+                $tvContent = normalize_url_tv_value($tvContent, postv('tv' . $tvId . '_prefix', '--'));
+            }
+        }
 
         // Save TV
         if ($tvId) {

--- a/assets/plugins/qm/qm.inc.php
+++ b/assets/plugins/qm/qm.inc.php
@@ -431,8 +431,10 @@ class Qm
         if (is_array($tvContent)) {
             $tvContent = implode('||', $tvContent);
         }
-        if ($tvId) {
-            $tvType = db()->getValue(db()->select('type', '[+prefix+]site_tmplvars', "id='{$tvId}'"));
+        if ($tvId || $tvName !== '') {
+            $tvType = $tvId
+                ? db()->getValue(db()->select('type', '[+prefix+]site_tmplvars', "id='" . (int)$tvId . "'"))
+                : db()->getValue(db()->select('type', '[+prefix+]site_tmplvars', "name='" . db()->escape($tvName) . "'"));
             if ($tvType === 'url') {
                 $tvContent = normalize_url_tv_value(
                     $tvContent,

--- a/assets/plugins/qm/qm.inc.php
+++ b/assets/plugins/qm/qm.inc.php
@@ -434,7 +434,10 @@ class Qm
         if ($tvId) {
             $tvType = db()->getValue(db()->select('type', '[+prefix+]site_tmplvars', "id='{$tvId}'"));
             if ($tvType === 'url') {
-                $tvContent = normalize_url_tv_value($tvContent, postv('tv' . $tvId . '_prefix', '--'));
+                $tvContent = normalize_url_tv_value(
+                    $tvContent,
+                    postv('tv' . $tvId . '_prefix', postv('tv' . $tvName . '_prefix', '--'))
+                );
             }
         }
 

--- a/manager/actions/document/mutate_content/fields.php
+++ b/manager/actions/document/mutate_content/fields.php
@@ -334,11 +334,7 @@ function fieldsTV()
                     $tvPBV = implode('||', $form_v[$tvid]);
                     break;
                 case 'url':
-                    if ($form_v[$tvid . '_prefix'] === 'DocID') {
-                        $tvPBV = sprintf('[~%s~]', $form_v[$tvid]);
-                    } else {
-                        $tvPBV = $form_v[$tvid . '_prefix'] . $form_v[$tvid];
-                    }
+                    $tvPBV = normalize_url_tv_value($form_v[$tvid], array_get($form_v, $tvid . '_prefix', '--'));
                     break;
                 default:
                     $tvPBV = $form_v[$tvid];

--- a/manager/actions/element/mutate_module.dynamic.php
+++ b/manager/actions/element/mutate_module.dynamic.php
@@ -623,7 +623,8 @@ function content($key, $default = null)
                         <p><?= $_lang['module_group_access_msg'] ?></p>
                     <?php
                     }
-                    $chk = '';
+                    $chks = '';
+                    $notPublic = false;
                     $rs = db()->select('name, id', '[+prefix+]membergroup_names');
                     $total = db()->count($rs);
                     for ($i = 0; $i < $total; $i++) {

--- a/manager/actions/element/mutate_tmplvars.dynamic.php
+++ b/manager/actions/element/mutate_tmplvars.dynamic.php
@@ -643,7 +643,8 @@ function entity($key, $default = null)
                         </script>
                         <p><?= $_lang['tmplvar_access_msg'] ?></p>
                         <?php
-                        $chk = '';
+                        $chks = '';
+                        $notPublic = false;
                         $rs = db()->select('name, id', '[+prefix+]documentgroup_names');
                         if (empty($groupsarray) && is_array(entity('docgroups')) && empty(entity('id'))) {
                             $groupsarray = entity('docgroups');

--- a/manager/includes/docvars/inputform/form_date.tpl
+++ b/manager/includes/docvars/inputform/form_date.tpl
@@ -1,4 +1,4 @@
 <input data-timepicker="[+timepicker+]" id="[+id+]" name="[+name+]" class="DatePicker" type="text" value="[+value+]"
        style="[+style+]" onblur="documentDirty=true;"/>
-<a onclick="document.forms['mutate'].elements['[+id+]'].value='';document.forms['mutate'].elements['[+id+]'].onblur(); return true;"
+<a onclick="document.forms['[+form_name+]'].elements['[+id+]'].value='';document.forms['[+form_name+]'].elements['[+id+]'].onblur(); return true;"
    style="cursor:pointer; cursor:hand"><img src="[+cal_nodate+]" border="0" alt="No date"></a>

--- a/manager/includes/docvars/inputform/form_file.tpl
+++ b/manager/includes/docvars/inputform/form_file.tpl
@@ -1,2 +1,2 @@
-<input type="text" id="tv%s" name="tv%s" value="%s" %s/>
+<input type="text" id="tv%s" name="tv%s" value="%s" style="%s"/>
 &nbsp;<input type="button" value="%s" onclick="BrowseFileServer('tv%s')"/>

--- a/manager/includes/docvars/inputform/form_image.tpl
+++ b/manager/includes/docvars/inputform/form_image.tpl
@@ -1,2 +1,2 @@
-<input type="text" id="tv%s" name="tv%s" value="%s" %s/>
+<input type="text" id="tv%s" name="tv%s" value="%s" style="%s"/>
 &nbsp;<input type="button" value="%s" onclick="BrowseServer('tv%s')"/>

--- a/manager/includes/docvars/inputform/form_url.tpl
+++ b/manager/includes/docvars/inputform/form_url.tpl
@@ -1,0 +1,12 @@
+<table border="0" cellspacing="0" cellpadding="0">
+    <tr>
+        <td>
+            <select id="[+prefix_id+]" name="[+prefix_name+]">
+                [+options+]
+            </select>
+        </td>
+        <td>
+            <input type="text" id="[+id+]" name="[+name+]" value="[+value+]" style="[+style+]"/>
+        </td>
+    </tr>
+</table>

--- a/manager/includes/helpers.php
+++ b/manager/includes/helpers.php
@@ -392,6 +392,37 @@ function postv($key = null, $default = null)
     return array_get($_POST, $key, $default);
 }
 
+function tv_url_prefixes()
+{
+    return ['--', 'http://', 'https://', 'ftp://', 'mailto:', 'DocID'];
+}
+
+function normalize_url_tv_value($value, $prefix = '--')
+{
+    $value = (string)($value ?? '');
+    $prefix = in_array($prefix, tv_url_prefixes(), true) ? $prefix : '--';
+
+    if ($prefix === 'DocID') {
+        return preg_match('/\A[0-9]+\z/', $value) ? '[~' . $value . '~]' : $value;
+    }
+
+    if ($prefix === '--') {
+        return $value;
+    }
+
+    foreach (tv_url_prefixes() as $knownPrefix) {
+        if ($knownPrefix === '--' || $knownPrefix === 'DocID') {
+            continue;
+        }
+        if (strpos($value, $knownPrefix) === 0) {
+            $value = substr($value, strlen($knownPrefix));
+            break;
+        }
+    }
+
+    return $prefix . $value;
+}
+
 function anyv($key = null, $default = null)
 {
     return array_get($_REQUEST, $key, $default);

--- a/manager/includes/traits/document.parser.subparser.trait.php
+++ b/manager/includes/traits/document.parser.subparser.trait.php
@@ -1382,6 +1382,11 @@ trait DocumentParserSubParserTrait
         global $modx, $content;
 
         $field_type = strtolower($field_type);
+        $default_text = (string)($default_text ?? '');
+        $field_elements = (string)($field_elements ?? '');
+        if ($field_value === null) {
+            $field_value = '';
+        }
 
         if (isset($content['id'])) {
             global $docObject;
@@ -1399,7 +1404,7 @@ trait DocumentParserSubParserTrait
         if (strpos($default_text, '<?php') === 0) {
             $default_text = "@@EVAL:\n" . substr($default_text, 6);
         }
-        if (strpos($field_value, '<?php') === 0) {
+        if (is_string($field_value) && strpos($field_value, '<?php') === 0) {
             $field_value = "@@EVAL:\n" . substr($field_value, 6);
         }
 
@@ -1408,15 +1413,18 @@ trait DocumentParserSubParserTrait
             $field_value = $default_text;
         }
 
-        if (in_array($field_type, ['text', 'rawtext', 'email', 'number', 'zipcode', 'tel', 'url'])) {
+        if (in_array($field_type, ['text', 'rawtext', 'email', 'number', 'zipcode', 'tel'])) {
             return $this->rendarFormText($field_type, $field_id, $field_value, $field_style);
+        }
+        if ($field_type === 'url') {
+            return $this->rendarFormUrl($field_id, $field_value, $field_style);
         }
 
         if (in_array($field_type, ['textarea', 'rawtextarea', 'htmlarea', 'richtext', 'textareamini'])) {
             return $this->rendarFormTextarea($field_type, $field_id, $field_value, $field_style);
         }
         if (in_array($field_type, ['date', 'dateonly'])) {
-            return $this->rendarFormDate($field_type, $field_id, $field_value, $field_style);
+            return $this->rendarFormDate($field_type, $field_id, $field_value, $field_style, $row);
         }
 
         if ($field_type === 'image') {
@@ -1471,11 +1479,11 @@ trait DocumentParserSubParserTrait
         }
 
         return sprintf(
-            '<input type="text" id="tv%s" name="tv%s" value="%s" %s />',
+            '<input type="text" id="tv%s" name="tv%s" value="%s" style="%s" />',
             $field_id,
             $field_id,
             $modx->hsc($field_value),
-            $field_style
+            $modx->hsc($field_style)
         );
     }
 
@@ -1516,12 +1524,63 @@ trait DocumentParserSubParserTrait
         );
     }
 
-    private function rendarFormDate($field_type, $field_id, $field_value, $field_style)
+    private function rendarFormUrl($field_id, $field_value, $field_style)
+    {
+        $field_value = (string)$field_value;
+        $prefixes = array_combine(tv_url_prefixes(), tv_url_prefixes());
+        $selectedPrefix = '--';
+
+        if (preg_match('/^\[~([0-9]+)~\]$/', $field_value, $matches)) {
+            $selectedPrefix = 'DocID';
+            $field_value = $matches[1];
+        } elseif (strpos($field_value, '--') === 0) {
+            $field_value = substr($field_value, 2);
+        } else {
+            foreach ($prefixes as $prefix => $label) {
+                if ($prefix === '--' || $prefix === 'DocID') {
+                    continue;
+                }
+                if (strpos($field_value, $prefix) === 0) {
+                    $selectedPrefix = $prefix;
+                    $field_value = substr($field_value, strlen($prefix));
+                    break;
+                }
+            }
+        }
+
+        $options = [];
+        foreach ($prefixes as $prefix => $label) {
+            $options[] = evo()->parseText(
+                '<option value="[+value+]" [+selected+]>[+label+]</option>',
+                [
+                    'value' => evo()->hsc($prefix),
+                    'label' => evo()->hsc($label),
+                    'selected' => $prefix === $selectedPrefix ? 'selected="selected"' : ''
+                ]
+            );
+        }
+
+        return evo()->parseText(
+            file_get_contents(MODX_CORE_PATH . 'docvars/inputform/form_url.tpl'),
+            [
+                'id' => 'tv' . $field_id,
+                'name' => 'tv' . $field_id,
+                'prefix_id' => 'tv' . $field_id . '_prefix',
+                'prefix_name' => 'tv' . $field_id . '_prefix',
+                'options' => implode("\n", $options),
+                'value' => evo()->hsc($field_value),
+                'style' => evo()->hsc($field_style)
+            ]
+        );
+    }
+
+    private function rendarFormDate($field_type, $field_id, $field_value, $field_style, $row = [])
     {
         $format = evo()->config('datetime_format');
         if ($field_type === 'date') {
             $format .= ' hh:mm:00';
         }
+        $formName = isset($row['form_name']) ? $row['form_name'] : 'mutate';
         return evo()->parseText(
             file_get_contents(MODX_CORE_PATH . 'docvars/inputform/form_date.tpl'),
             [
@@ -1531,8 +1590,9 @@ trait DocumentParserSubParserTrait
                 ),
                 'name'            => 'tv' . $field_id,
                 'value'           => $field_value ? evo()->hsc($field_value) : '',
-                'style'           => $field_style,
+                'style'           => evo()->hsc($field_style),
                 'tvtype'          => $field_type,
+                'form_name'       => evo()->hsc($formName),
                 'cal_nodate'      => style('icons_cal_nodate'),
                 'yearOffset'      => evo()->config('datepicker_offset'),
                 'datetime_format' => $format,
@@ -1642,8 +1702,8 @@ trait DocumentParserSubParserTrait
             file_get_contents(MODX_CORE_PATH . 'docvars/inputform/form_image.tpl'),
             $field_id,
             $field_id,
-            $field_value,
-            $field_style,
+            evo()->hsc($field_value),
+            evo()->hsc($field_style),
             lang('insert'),
             $field_id
         );
@@ -1655,8 +1715,8 @@ trait DocumentParserSubParserTrait
             file_get_contents(MODX_CORE_PATH . 'docvars/inputform/form_file.tpl'),
             $field_id,
             $field_id,
-            $field_value,
-            $field_style,
+            evo()->hsc($field_value),
+            evo()->hsc($field_style),
             lang('insert'),
             $field_id
         );
@@ -2246,11 +2306,7 @@ trait DocumentParserSubParserTrait
                 $name = $tvname[$k];
                 $prefix_key = "{$k}_prefix";
                 if (isset($input[$prefix_key])) {
-                    if ($input[$prefix_key] !== 'DocID') {
-                        $v = $input[$prefix_key] . $v;
-                    } elseif (preg_match('/\A[0-9]+\z/', $v)) {
-                        $v = '[~' . $v . '~]';
-                    }
+                    $v = normalize_url_tv_value($v, $input[$prefix_key]);
                 }
                 unset($input[$k]);
                 $input[$name] = $v;

--- a/manager/includes/traits/document.parser.subparser.trait.php
+++ b/manager/includes/traits/document.parser.subparser.trait.php
@@ -1563,10 +1563,10 @@ trait DocumentParserSubParserTrait
         return evo()->parseText(
             file_get_contents(MODX_CORE_PATH . 'docvars/inputform/form_url.tpl'),
             [
-                'id' => 'tv' . $field_id,
-                'name' => 'tv' . $field_id,
-                'prefix_id' => 'tv' . $field_id . '_prefix',
-                'prefix_name' => 'tv' . $field_id . '_prefix',
+                'id' => evo()->hsc('tv' . $field_id),
+                'name' => evo()->hsc('tv' . $field_id),
+                'prefix_id' => evo()->hsc('tv' . $field_id . '_prefix'),
+                'prefix_name' => evo()->hsc('tv' . $field_id . '_prefix'),
                 'options' => implode("\n", $options),
                 'value' => evo()->hsc($field_value),
                 'style' => evo()->hsc($field_style)
@@ -2295,7 +2295,7 @@ trait DocumentParserSubParserTrait
             $tvname = [];
             while ($row = db()->getRow($rs)) {
                 $tvid = 'tv' . $row['id'];
-                $tvname[$tvid] = $row['name'];
+                $tvname[$tvid] = ['name' => $row['name'], 'type' => $row['type']];
             }
 
         foreach ($input as $k => $v) {
@@ -2303,9 +2303,9 @@ trait DocumentParserSubParserTrait
                 if (is_array($v)) {
                     $v = implode('||', $v);
                 }
-                $name = $tvname[$k];
+                $name = $tvname[$k]['name'];
                 $prefix_key = "{$k}_prefix";
-                if (isset($input[$prefix_key])) {
+                if (($tvname[$k]['type'] ?? '') === 'url' && isset($input[$prefix_key])) {
                     $v = normalize_url_tv_value($v, $input[$prefix_key]);
                 }
                 unset($input[$k]);

--- a/manager/processors/document/save_resource.processor.php
+++ b/manager/processors/document/save_resource.processor.php
@@ -195,16 +195,7 @@ function get_tmplvars()
         }
 
         if ($row['type'] === 'url') {
-            if (validated($tvid . '_prefix') === 'DocID') {
-                $value = validated($tvid);
-                if (preg_match('/\A[0-9]+\z/', $value)) {
-                    $value = '[~' . $value . '~]';
-                }
-            } elseif (validated($tvid . '_prefix') !== '--') {
-                $value = validated($tvid . '_prefix') . validated($tvid);
-            } else {
-                $value = validated($tvid);
-            }
+            $value = normalize_url_tv_value(validated($tvid), validated($tvid . '_prefix', '--'));
         } elseif ($row['type'] === 'file') {
             $value = validated($tvid);
         } elseif (is_array(validated($tvid))) {


### PR DESCRIPTION
closes #410 の内容を再現（ブランチ誤削除による再PR）

https://forum.modx.jp/viewtopic.php?t=2036

## 概要

- `normalize_url_tv_value()` / `tv_url_prefixes()` を `helpers.php` に追加し、URL型TVの保存処理を各所で共通化
- `rendarFormUrl()` を新規追加し URL型TVを `form_url.tpl` テンプレートで描画（DocIDプレフィックス対応含む）
- `rendarFormDate()` に `$row` 引数を追加し `form_name` を動的に切り替え可能に（docmanagerとmutateで異なるフォーム名に対応）
- `rendarFormImage()` / `rendarFormFile()` に `hsc()` を適用しXSS対策を強化
- `tv.ajax.php` のローカル `renderFormElement` を削除しコアの実装（`tmplvars.inc.php`）を利用
- `tv.ajax.php` のJOINをINNER JOINに変更しORDER BY（`tvtpl.rank, tv.rank, tv.id`）を追加
- `main.tpl` にブラウザ操作JS関数（`OpenServerBrowser`/`BrowseServer`/`BrowseFileServer`/`SetUrl`）を移動しPHP生成コードを削減
- `renderFormElement()` の引数にnullチェックとstring型キャストを追加しPHP8での警告を解消

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `manager/includes/helpers.php` | `tv_url_prefixes()` と `normalize_url_tv_value()` を新規追加 |
| `manager/includes/docvars/inputform/form_url.tpl` | 新規テンプレートファイル作成 |
| `manager/includes/docvars/inputform/form_date.tpl` | フォーム名を `[+form_name+]` プレースホルダーに変更 |
| `manager/includes/docvars/inputform/form_file.tpl` `form_image.tpl` | `style="%s"` 形式に修正 |
| `manager/includes/traits/document.parser.subparser.trait.php` | `rendarFormUrl()` 追加、null安全処理、`hsc()` 適用、`rendarFormDate()` に `$row` 引数追加 |
| `assets/modules/docmanager/tv.ajax.php` | ローカル `renderFormElement` を削除しコアのものを利用、INNER JOIN・ORDER BY追加 |
| `assets/modules/docmanager/templates/main.tpl` | ブラウザ操作JS関数をテンプレートへ移動 |
| `assets/modules/docmanager/classes/dm_backend.class.php` | `normalize_url_tv_value()` を利用 |
| `assets/plugins/qm/qm.inc.php` | URL TV保存時に正規化処理を追加 |
| `manager/actions/document/mutate_content/fields.php` `save_resource.processor.php` | `normalize_url_tv_value()` を利用 |
| `manager/actions/element/mutate_module.dynamic.php` `mutate_tmplvars.dynamic.php` | `$chk` → `$chks`、`$notPublic` 初期化 |

## Test plan

- [ ] URL型TVを持つドキュメントを編集し保存できること
- [ ] URL型TVのプレフィックス（`http://`/`https://`/`ftp://`/`mailto:`/`DocID`/`--`）が正しく保存されること
- [ ] DocIDプレフィックスで数値入力時に `[~ID~]` 形式で保存されること
- [ ] date型TVの「日付クリア」ボタンが docmanager モジュール内で機能すること
- [ ] image/file型TVのブラウザボタンが機能すること
- [ ] docmanagerモジュールのTV一覧がAJAXで正しく表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * URL入力フォームテンプレートを追加しました
  * ファイル／画像ブラウザーのクライアント連携を強化し、ポップアップから選択したURLをフォームへ反映できるようになりました

* **Bug Fixes**
  * URL型テンプレート変数の取り扱いを正規化し一貫性を向上しました
  * 各種フォーム出力で値・スタイルの適切なエスケープとフォーム名参照の不具合を修正しました

* **Refactor**
  * URL正規化ロジックを共通ヘルパーに統合しました

* **Chores**
  * 開発設定ファイルを更新しました

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/modxcms-jp/evolution-jp/pull/449)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->