### PR TITLE
fix: jQuery.trimの依存を除去

### DIFF
--- a/assets/plugins/managermanager/widgets/ddmultiplefields/ddmultiplefields.php
+++ b/assets/plugins/managermanager/widgets/ddmultiplefields/ddmultiplefields.php
@@ -91,12 +91,15 @@ var ddMultiple = {
 datePickerOffset: ' . evo()->config('datepicker_offset') . ',
 datePickerFormat: "' . evo()->config('datetime_format') . '" + " hh:mm:00",
 ids: [],
+trimValue: function(value){
+    return String(value == null ? "" : value).trim();
+},
 //Обновляет мульти-поле, берёт значение из оригинального поля
 updateField: function(id){
     //Если есть текущее поле
     if (ddMultiple[id].currentField){
         //Задаём значение текущему полю (берём у оригинального поля), запускаем событие изменения
-        ddMultiple[id].currentField.val(jQuery.trim(jQuery("#" + id).val())).trigger("change.ddEvents");
+        ddMultiple[id].currentField.val(ddMultiple.trimValue(jQuery("#" + id).val())).trigger("change.ddEvents");
         //Забываем текущее поле (ибо уже обработали)
         ddMultiple[id].currentField = false;
     }
@@ -127,7 +130,7 @@ updateTv: function(id){
                 id_field.$field.val("");
             }
             //Собираем значения строки в массив
-            masCol.push(jQuery.trim(jQuery(this).val()));
+            masCol.push(ddMultiple.trimValue(jQuery(this).val()));
         });
 
         var col = masCol.join(ddMultiple[id].splX);

--- a/assets/plugins/managermanager/widgets/mm_requirefields/mm_requirefields.php
+++ b/assets/plugins/managermanager/widgets/mm_requirefields/mm_requirefields.php
@@ -109,7 +109,7 @@ function mm_requireFields($fields, $roles = '', $templates = '')
 var $sel = jQuery("' . $selector . '");
 
 // Check if its valid
-if(jQuery.trim($sel.val()) == ""){  // If it is empty
+if(String($sel.val() == null ? "" : $sel.val()).trim() == ""){  // If it is empty
 
 // Find the label (this will be easier in Evo 1.1 with more semantic code)
 var lbl = $sel.parent("td").prev("td").children("span.warning").text().replace(jQuery(requiredHTML).text(), "");

--- a/assets/plugins/managermanager/widgets/mm_requirefields/mm_requirefields.php
+++ b/assets/plugins/managermanager/widgets/mm_requirefields/mm_requirefields.php
@@ -107,9 +107,10 @@ function mm_requireFields($fields, $roles = '', $templates = '')
 
 // The element we are targetting (' . $fieldname . ')
 var $sel = jQuery("' . $selector . '");
+var fieldValue = $sel.val();
 
 // Check if its valid
-if(String($sel.val() == null ? "" : $sel.val()).trim() == ""){  // If it is empty
+if(String(fieldValue == null ? "" : fieldValue).trim() == ""){  // If it is empty
 
 // Find the label (this will be easier in Evo 1.1 with more semantic code)
 var lbl = $sel.parent("td").prev("td").children("span.warning").text().replace(jQuery(requiredHTML).text(), "");

--- a/assets/plugins/managermanager/widgets/tags/tags.js
+++ b/assets/plugins/managermanager/widgets/tags/tags.js
@@ -1,6 +1,9 @@
 // If we haven't yet got the function
 if (typeof (TagCompleter) != 'function') {
     function TagCompleter(tagEntryField, tagIndicatorList, delimiter) {
+        var trimValue = function (value) {
+            return String(value == null ? '' : value).trim();
+        };
 
         var theEntry = jQuery('#' + tagEntryField);
         var theList = jQuery('#' + tagIndicatorList);
@@ -28,7 +31,7 @@ if (typeof (TagCompleter) != 'function') {
             // Trim each item of whitespace at the beginning and end
             var theTags = jQuery(theEntry).val().split(delimiter);
             jQuery.each(theTags, function (i, v) {
-                theTags[i] = jQuery.trim(v);
+                theTags[i] = trimValue(v);
                 if (theTags[i] == '') {
                     theTags.splice(i, 1);
                 } // Remove any empty values
@@ -40,7 +43,7 @@ if (typeof (TagCompleter) != 'function') {
         var addTag = function (e) {
             var newTag = jQuery(e.target).text();
             newTag = newTag.replace(/\([0-9]+\)$/, '');
-            newTag = jQuery.trim(newTag);
+            newTag = trimValue(newTag);
             var oldTags = getTags();
             // Mark the document as dirty for Modx by triggering a "change" event
             jQuery(theEntry).trigger("change");
@@ -64,7 +67,7 @@ if (typeof (TagCompleter) != 'function') {
 
             jQuery('#' + tagIndicatorList + ' li').each(function () {
                 tag = jQuery(this).text().replace(/\([0-9]+\)$/, '');
-                tag = jQuery.trim(tag);
+                tag = trimValue(tag);
                 if (jQuery.inArray(tag, tagsInField) != -1) {
                     jQuery(this).addClass('tagSelected');
                 } else {


### PR DESCRIPTION
## 概要
- deprecated な jQuery.trim() 依存を managermanager 関連の残存箇所から除去
- null を空文字として扱う既存挙動を維持したまま String(...).trim() へ置換

## 変更内容
- ddmultiplefields の trim 処理をローカル helper 経由に統一
- tags widget の trim 処理をローカル helper 経由に統一
- mm_requirefields の空判定を String(...).trim() へ置換

## 確認
- rg -n "jQuery\.trim|\$\.trim" . で残存なし
- php -l assets/plugins/managermanager/widgets/ddmultiplefields/ddmultiplefields.php
- php -l assets/plugins/managermanager/widgets/mm_requirefields/mm_requirefields.php