### PR TITLE
fix(manager): 管理画面ルートをダッシュボードへ正規化

### DIFF
--- a/manager/actions/main/welcome.static.php
+++ b/manager/actions/main/welcome.static.php
@@ -253,7 +253,7 @@ echo $welcome_tpl;
 function get_icon($title, $action, $icon_path, $alt = '')
 {
     if (preg_match('@^[1-9][0-9]*$@', $action)) {
-        $action = 'index.php?a=' . $action;
+        $action = (int)$action === 2 ? './' : 'index.php?a=' . $action;
     }
     $icon = '<a class="hometblink" href="' . $action . '" alt="' . $alt . '"><img src="' . $icon_path . '" /><br />' . $title . "</a>\n";
     return '<span class="wm_button" style="border:0">' . $icon . '</span>';

--- a/manager/frames/menu.php
+++ b/manager/frames/menu.php
@@ -456,7 +456,7 @@ function item($name, $href, $display = 1, $attrib = '')
         return false;
     }
     if (preg_match('@^[1-9][0-9]*$@', $href)) {
-        $href = "index.php?a={$href}";
+        $href = (int)$href === 2 ? './' : "index.php?a={$href}";
     }
     return sprintf('<li><a onclick="this.blur();" href="%s" %s>%s</a></li>', $href, $attrib, $name);
 }

--- a/manager/includes/helpers.php
+++ b/manager/includes/helpers.php
@@ -802,3 +802,13 @@ if (!function_exists('evoRenderPaneFooterExtras')) {
         }
     }
 }
+
+if (!function_exists('manager_is_dashboard_action')) {
+    function manager_is_dashboard_action(): bool
+    {
+        return defined('IN_MANAGER_MODE')
+            && IN_MANAGER_MODE === 'true'
+            && manager()
+            && (int)manager()->action === 2;
+    }
+}

--- a/manager/index.php
+++ b/manager/index.php
@@ -64,6 +64,9 @@ $modx->loadLexicon('manager');
 header(sprintf('Content-Type: text/html; charset=%s', config('modx_charset', 'utf-8')));
 
 manager()->action = anyv('a', 1);
+if (!evo()->input_any('a') && postv('updateMsgCount') === null && !sessionv('mainframe.a') && !sessionv('mgrForgetPassword')) {
+    manager()->action = 2;
+}
 
 // accesscontrol.php checks to see if the user is logged in. If not, a log in form is shown
 include_once(MODX_CORE_PATH . 'accesscontrol.inc.php');
@@ -149,7 +152,6 @@ if (!evo()->input_any('a') && !alert()->hasError() && postv('updateMsgCount') ==
         header('Location: ' . MODX_MANAGER_URL . 'index.php?a=28');
         exit;
     }
-    manager()->action = 2;
 }
 
 // OK, let's retrieve the action directive from the request
@@ -166,13 +168,18 @@ if (
     && !isEvoPaneRequest()
     && postv('updateMsgCount') === null
 ) {
-    $canonicalQuery = $_GET;
+    $canonicalQuery = [];
+    parse_str((string)parse_url(request_uri(), PHP_URL_QUERY), $canonicalQuery);
     unset($canonicalQuery['a']);
     $canonicalUrl = MODX_MANAGER_URL;
     if (!empty($canonicalQuery)) {
         $canonicalUrl .= '?' . http_build_query($canonicalQuery);
     }
-    if ($canonicalUrl !== MODX_SITE_URL . ltrim(serverv('REQUEST_URI', ''), '/')) {
+    $canonicalPath = (string)parse_url($canonicalUrl, PHP_URL_PATH);
+    $canonicalQueryString = (string)parse_url($canonicalUrl, PHP_URL_QUERY);
+    $currentPath = (string)parse_url(request_uri(), PHP_URL_PATH);
+    $currentQueryString = http_build_query($canonicalQuery);
+    if ($currentPath !== $canonicalPath || $currentQueryString !== $canonicalQueryString) {
         header('Location: ' . $canonicalUrl);
         exit;
     }

--- a/manager/index.php
+++ b/manager/index.php
@@ -137,18 +137,19 @@ if (!isset($_SESSION['SystemAlertMsgQueque'])) {
 }
 $modx->SystemAlertMsgQueque = &$_SESSION['SystemAlertMsgQueque'];
 
-// 旧framesetの入口。シェル化に伴い、初期表示アクションへリダイレクトする
+// 旧framesetの入口。a未指定時はダッシュボードを既定表示にする
 if (!evo()->input_any('a') && !alert()->hasError() && postv('updateMsgCount') === null) {
     if (sessionv('mainframe.a')) {
         $mainurl = 'index.php?' . http_build_query(sessionv('mainframe'));
         sessionv('*mainframe', null);
-    } elseif (sessionv('mgrForgetPassword')) {
-        $mainurl = 'index.php?a=28';
-    } else {
-        $mainurl = 'index.php?a=2';
+        header('Location: ' . MODX_MANAGER_URL . $mainurl);
+        exit;
     }
-    header('Location: ' . MODX_MANAGER_URL . $mainurl);
-    exit;
+    if (sessionv('mgrForgetPassword')) {
+        header('Location: ' . MODX_MANAGER_URL . 'index.php?a=28');
+        exit;
+    }
+    manager()->action = 2;
 }
 
 // OK, let's retrieve the action directive from the request
@@ -156,7 +157,25 @@ if (getv('a') && postv('a')) {
     alert()->setError(100);
     alert()->dumpError();
 } else {
-    $modx->manager->action = (int)anyv('a') ?: '';
+    $modx->manager->action = evo()->input_any('a') ? ((int)anyv('a') ?: '') : (int)manager()->action;
+}
+
+if (
+    manager()->action === 2
+    && is_get()
+    && !isEvoPaneRequest()
+    && postv('updateMsgCount') === null
+) {
+    $canonicalQuery = $_GET;
+    unset($canonicalQuery['a']);
+    $canonicalUrl = MODX_MANAGER_URL;
+    if (!empty($canonicalQuery)) {
+        $canonicalUrl .= '?' . http_build_query($canonicalQuery);
+    }
+    if ($canonicalUrl !== MODX_SITE_URL . ltrim(serverv('REQUEST_URI', ''), '/')) {
+        header('Location: ' . $canonicalUrl);
+        exit;
+    }
 }
 
 manager()->setView(manager()->action);

--- a/manager/index.php
+++ b/manager/index.php
@@ -163,7 +163,7 @@ if (getv('a') && postv('a')) {
 }
 
 if (
-    manager()->action === 2
+    manager_is_dashboard_action()
     && is_get()
     && !isEvoPaneRequest()
     && postv('updateMsgCount') === null

--- a/manager/media/script/shell.js
+++ b/manager/media/script/shell.js
@@ -43,6 +43,18 @@
         return resolved.pathname === base + 'index.php' || resolved.pathname === base;
     }
 
+    function normalizeManagerUrl(url) {
+        const resolved = new URL(url, window.location.href);
+        if (!isManagerUrl(resolved.href)) {
+            return resolved.href;
+        }
+        if (resolved.searchParams.get('a') === '2') {
+            resolved.searchParams.delete('a');
+            resolved.pathname = window.location.pathname.replace(/(?:index\.php)?$/, '');
+        }
+        return resolved.href;
+    }
+
     function getCsrfToken() {
         const meta = document.querySelector('meta[name="csrf-token"]');
         return meta ? meta.getAttribute('content') : '';
@@ -123,7 +135,7 @@
     }
 
     function fullReload(url) {
-        window.location.href = url;
+        window.location.href = normalizeManagerUrl(url);
     }
 
     function isFullDocumentHtml(text) {
@@ -168,7 +180,7 @@
         if (requested.hash) {
             finalUrl.hash = requested.hash;
         }
-        return finalUrl.href;
+        return normalizeManagerUrl(finalUrl.href);
     }
 
     // 断片内のスタイルシートを<head>へ移す。
@@ -539,7 +551,7 @@
             if (!confirmIfDirty()) {
                 return;
             }
-            request(url, { method: 'GET' }, push);
+            request(normalizeManagerUrl(url), { method: 'GET' }, push);
         },
 
         submit: function (form, submitter) {
@@ -666,15 +678,15 @@
                 return;
             }
             const url = new URL(href, window.location.href);
-            if (!url.searchParams.get('a')) {
+            if (!url.searchParams.get('a') && !(url.pathname === window.location.pathname.replace(/[^\/]*$/, '') && !url.search)) {
                 return;
             }
             e.preventDefault();
             if (link.hasAttribute('data-modal')) {
-                EvoShell.openModal(url.href);
+                EvoShell.openModal(normalizeManagerUrl(url.href));
                 return;
             }
-            EvoShell.navigate(url.href);
+            EvoShell.navigate(normalizeManagerUrl(url.href));
         });
 
         // コンテンツ領域のフォーム送信の委譲

--- a/manager/media/style/AromaHop/welcome.php
+++ b/manager/media/style/AromaHop/welcome.php
@@ -8,7 +8,7 @@ function iconMessage()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('messages')) {
         $ph['imgsrc'] = (sessionv('nrnewmessages', 0) > 0) ? 'icons/32x/mail_new.png' : 'icons/32x/mail.png';
         $ph['action'] = 'index.php?a=10';
@@ -21,7 +21,7 @@ function iconElements()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('new_template') || evo()->hasPermission('edit_template') || evo()->hasPermission('new_snippet') || evo()->hasPermission('edit_snippet') || evo()->hasPermission('new_plugin') || evo()->hasPermission('edit_plugin')) {
         $ph['imgsrc'] = 'icons/32x/elements.png';
         $ph['action'] = 'index.php?a=76';
@@ -34,7 +34,7 @@ function iconNewDoc()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('new_document') || evo()->hasPermission('save_document')) {
         $ph['imgsrc'] = 'icons/32x/newdoc.png';
         $ph['action'] = 'index.php?a=4';
@@ -47,7 +47,7 @@ function iconSettings()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('settings')) {
         $ph['imgsrc'] = 'icons/32x/settings.png';
         $ph['action'] = 'index.php?a=17';
@@ -60,7 +60,7 @@ function iconResources()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('view_document')) {
         $ph['imgsrc'] = 'icons/32x/resources.png';
         $ph['action'] = 'index.php?a=120';
@@ -73,7 +73,7 @@ function iconHelp()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('help')) {
         $ph['imgsrc'] = 'icons/32x/help.png';
         $ph['action'] = 'index.php?a=9';
@@ -86,7 +86,7 @@ function iconFileManager()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('file_manager')) {
         $ph['imgsrc'] = 'icons/32x/files.png';
         $ph['action'] = 'index.php?a=31';
@@ -99,7 +99,7 @@ function iconEventLog()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('view_eventlog')) {
         $ph['imgsrc'] = 'icons/32x/log.png';
         $ph['action'] = 'index.php?a=114';
@@ -112,7 +112,7 @@ function iconSysInfo()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('logs')) {
         $ph['imgsrc'] = 'icons/32x/info.png';
         $ph['action'] = 'index.php?a=53';
@@ -125,7 +125,7 @@ function iconSearch()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     $ph['imgsrc'] = 'icons/32x/search.png';
     $ph['action'] = 'index.php?a=71';
     $ph['title'] = $_lang['search_resource'];
@@ -136,7 +136,7 @@ function tabYourInfo()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
 
     $ph = $_lang;
 
@@ -224,7 +224,7 @@ function tabOnlineUser()
 {
     global $modx, $_lang, $style_tree_path;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     $ph = $_lang;
     $timetocheck = (time() - (60 * 20));//+$server_offset_time;
 

--- a/manager/media/style/AuroraFlow/welcome.php
+++ b/manager/media/style/AuroraFlow/welcome.php
@@ -8,7 +8,7 @@ function iconMessage()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('messages')) {
         $ph['imgsrc'] = (sessionv('nrnewmessages', 0) > 0) ? 'icons/32x/mail_new.png' : 'icons/32x/mail.png';
         $ph['action'] = 'index.php?a=10';
@@ -21,7 +21,7 @@ function iconElements()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('new_template') || evo()->hasPermission('edit_template') || evo()->hasPermission('new_snippet') || evo()->hasPermission('edit_snippet') || evo()->hasPermission('new_plugin') || evo()->hasPermission('edit_plugin')) {
         $ph['imgsrc'] = 'icons/32x/elements.png';
         $ph['action'] = 'index.php?a=76';
@@ -34,7 +34,7 @@ function iconNewDoc()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('new_document') || evo()->hasPermission('save_document')) {
         $ph['imgsrc'] = 'icons/32x/newdoc.png';
         $ph['action'] = 'index.php?a=4';
@@ -47,7 +47,7 @@ function iconSettings()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('settings')) {
         $ph['imgsrc'] = 'icons/32x/settings.png';
         $ph['action'] = 'index.php?a=17';
@@ -60,7 +60,7 @@ function iconResources()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('view_document')) {
         $ph['imgsrc'] = 'icons/32x/resources.png';
         $ph['action'] = 'index.php?a=120';
@@ -73,7 +73,7 @@ function iconHelp()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('help')) {
         $ph['imgsrc'] = 'icons/32x/help.png';
         $ph['action'] = 'index.php?a=9';
@@ -86,7 +86,7 @@ function iconFileManager()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('file_manager')) {
         $ph['imgsrc'] = 'icons/32x/files.png';
         $ph['action'] = 'index.php?a=31';
@@ -99,7 +99,7 @@ function iconEventLog()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('view_eventlog')) {
         $ph['imgsrc'] = 'icons/32x/log.png';
         $ph['action'] = 'index.php?a=114';
@@ -112,7 +112,7 @@ function iconSysInfo()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('logs')) {
         $ph['imgsrc'] = 'icons/32x/info.png';
         $ph['action'] = 'index.php?a=53';
@@ -125,7 +125,7 @@ function iconSearch()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     $ph['imgsrc'] = 'icons/32x/search.png';
     $ph['action'] = 'index.php?a=71';
     $ph['title'] = $_lang['search_resource'];
@@ -136,7 +136,7 @@ function tabYourInfo()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
 
     $ph = $_lang;
 
@@ -224,7 +224,7 @@ function tabOnlineUser()
 {
     global $modx, $_lang, $style_tree_path;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     $ph = $_lang;
     $timetocheck = (time() - (60 * 20));//+$server_offset_time;
 

--- a/manager/media/style/RevoClassic/welcome.php
+++ b/manager/media/style/RevoClassic/welcome.php
@@ -8,7 +8,7 @@ function iconMessage()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('messages')) {
         $ph['imgsrc'] = (sessionv('nrnewmessages', 0) > 0) ? 'icons/32x/mail_new.png' : 'icons/32x/mail.png';
         $ph['action'] = 'index.php?a=10';
@@ -21,7 +21,7 @@ function iconElements()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('new_template') || evo()->hasPermission('edit_template') || evo()->hasPermission('new_snippet') || evo()->hasPermission('edit_snippet') || evo()->hasPermission('new_plugin') || evo()->hasPermission('edit_plugin')) {
         $ph['imgsrc'] = 'icons/32x/elements.png';
         $ph['action'] = 'index.php?a=76';
@@ -34,7 +34,7 @@ function iconNewDoc()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('new_document') || evo()->hasPermission('save_document')) {
         $ph['imgsrc'] = 'icons/32x/newdoc.png';
         $ph['action'] = 'index.php?a=4';
@@ -47,7 +47,7 @@ function iconSettings()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('settings')) {
         $ph['imgsrc'] = 'icons/32x/settings.png';
         $ph['action'] = 'index.php?a=17';
@@ -60,7 +60,7 @@ function iconResources()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('view_document')) {
         $ph['imgsrc'] = 'icons/32x/resources.png';
         $ph['action'] = 'index.php?a=120';
@@ -73,7 +73,7 @@ function iconHelp()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('help')) {
         $ph['imgsrc'] = 'icons/32x/help.png';
         $ph['action'] = 'index.php?a=9';
@@ -86,7 +86,7 @@ function iconFileManager()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('file_manager')) {
         $ph['imgsrc'] = 'icons/32x/files.png';
         $ph['action'] = 'index.php?a=31';
@@ -99,7 +99,7 @@ function iconEventLog()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('view_eventlog')) {
         $ph['imgsrc'] = 'icons/32x/log.png';
         $ph['action'] = 'index.php?a=114';
@@ -112,7 +112,7 @@ function iconSysInfo()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('logs')) {
         $ph['imgsrc'] = 'icons/32x/info.png';
         $ph['action'] = 'index.php?a=53';
@@ -125,7 +125,7 @@ function iconSearch()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     $ph['imgsrc'] = 'icons/32x/search.png';
     $ph['action'] = 'index.php?a=71';
     $ph['title'] = $_lang['search_resource'];
@@ -136,7 +136,7 @@ function tabYourInfo()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
 
     $ph = $_lang;
 
@@ -224,7 +224,7 @@ function tabOnlineUser()
 {
     global $modx, $_lang, $style_tree_path;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     $ph = $_lang;
     $timetocheck = (time() - (60 * 20));//+$server_offset_time;
 

--- a/manager/media/style/RevoStyle/welcome.php
+++ b/manager/media/style/RevoStyle/welcome.php
@@ -8,7 +8,7 @@ function iconMessage()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('messages')) {
         $ph['imgsrc'] = (sessionv('nrnewmessages', 0) > 0) ? 'icons/32x/mail_new.png' : 'icons/32x/mail.png';
         $ph['action'] = 'index.php?a=10';
@@ -21,7 +21,7 @@ function iconElements()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('new_template') || evo()->hasPermission('edit_template') || evo()->hasPermission('new_snippet') || evo()->hasPermission('edit_snippet') || evo()->hasPermission('new_plugin') || evo()->hasPermission('edit_plugin')) {
         $ph['imgsrc'] = 'icons/32x/elements.png';
         $ph['action'] = 'index.php?a=76';
@@ -34,7 +34,7 @@ function iconNewDoc()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('new_document') || evo()->hasPermission('save_document')) {
         $ph['imgsrc'] = 'icons/32x/newdoc.png';
         $ph['action'] = 'index.php?a=4';
@@ -47,7 +47,7 @@ function iconSettings()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('settings')) {
         $ph['imgsrc'] = 'icons/32x/settings.png';
         $ph['action'] = 'index.php?a=17';
@@ -60,7 +60,7 @@ function iconResources()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('view_document')) {
         $ph['imgsrc'] = 'icons/32x/resources.png';
         $ph['action'] = 'index.php?a=120';
@@ -73,7 +73,7 @@ function iconHelp()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('help')) {
         $ph['imgsrc'] = 'icons/32x/help.png';
         $ph['action'] = 'index.php?a=9';
@@ -86,7 +86,7 @@ function iconFileManager()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('file_manager')) {
         $ph['imgsrc'] = 'icons/32x/files.png';
         $ph['action'] = 'index.php?a=31';
@@ -99,7 +99,7 @@ function iconEventLog()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('view_eventlog')) {
         $ph['imgsrc'] = 'icons/32x/log.png';
         $ph['action'] = 'index.php?a=114';
@@ -112,7 +112,7 @@ function iconSysInfo()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('logs')) {
         $ph['imgsrc'] = 'icons/32x/info.png';
         $ph['action'] = 'index.php?a=53';
@@ -125,7 +125,7 @@ function iconSearch()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     $ph['imgsrc'] = 'icons/32x/search.png';
     $ph['action'] = 'index.php?a=71';
     $ph['title'] = $_lang['search_resource'];
@@ -136,7 +136,7 @@ function tabYourInfo()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
 
     $ph = $_lang;
 
@@ -224,7 +224,7 @@ function tabOnlineUser()
 {
     global $modx, $_lang, $style_tree_path;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     $ph = $_lang;
     $timetocheck = (time() - (60 * 20));//+$server_offset_time;
 

--- a/manager/media/style/RubberWhite/welcome.php
+++ b/manager/media/style/RubberWhite/welcome.php
@@ -8,7 +8,7 @@ function iconMessage()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('messages')) {
         $ph['imgsrc'] = (sessionv('nrnewmessages', 0) > 0) ? 'icons/32x/mail_new.png' : 'icons/32x/mail.png';
         $ph['action'] = 'index.php?a=10';
@@ -21,7 +21,7 @@ function iconElements()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('new_template') || evo()->hasPermission('edit_template') || evo()->hasPermission('new_snippet') || evo()->hasPermission('edit_snippet') || evo()->hasPermission('new_plugin') || evo()->hasPermission('edit_plugin')) {
         $ph['imgsrc'] = 'icons/32x/elements.png';
         $ph['action'] = 'index.php?a=76';
@@ -34,7 +34,7 @@ function iconNewDoc()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('new_document') || evo()->hasPermission('save_document')) {
         $ph['imgsrc'] = 'icons/32x/newdoc.png';
         $ph['action'] = 'index.php?a=4';
@@ -47,7 +47,7 @@ function iconSettings()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('settings')) {
         $ph['imgsrc'] = 'icons/32x/settings.png';
         $ph['action'] = 'index.php?a=17';
@@ -60,7 +60,7 @@ function iconResources()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('view_document')) {
         $ph['imgsrc'] = 'icons/32x/resources.png';
         $ph['action'] = 'index.php?a=120';
@@ -73,7 +73,7 @@ function iconHelp()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('help')) {
         $ph['imgsrc'] = 'icons/32x/help.png';
         $ph['action'] = 'index.php?a=9';
@@ -86,7 +86,7 @@ function iconFileManager()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('file_manager')) {
         $ph['imgsrc'] = 'icons/32x/files.png';
         $ph['action'] = 'index.php?a=31';
@@ -99,7 +99,7 @@ function iconEventLog()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('view_eventlog')) {
         $ph['imgsrc'] = 'icons/32x/log.png';
         $ph['action'] = 'index.php?a=114';
@@ -112,7 +112,7 @@ function iconSysInfo()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('logs')) {
         $ph['imgsrc'] = 'icons/32x/info.png';
         $ph['action'] = 'index.php?a=53';
@@ -125,7 +125,7 @@ function iconSearch()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     $ph['imgsrc'] = 'icons/32x/search.png';
     $ph['action'] = 'index.php?a=71';
     $ph['title'] = $_lang['search_resource'];
@@ -136,7 +136,7 @@ function tabYourInfo()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
 
     $ph = $_lang;
 
@@ -224,7 +224,7 @@ function tabOnlineUser()
 {
     global $modx, $_lang, $style_tree_path;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     $ph = $_lang;
     $timetocheck = (time() - (60 * 20));//+$server_offset_time;
 

--- a/manager/media/style/SakuraFlow/welcome.php
+++ b/manager/media/style/SakuraFlow/welcome.php
@@ -8,7 +8,7 @@ function iconMessage()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('messages')) {
         $ph['imgsrc'] = (sessionv('nrnewmessages', 0) > 0) ? 'icons/32x/mail_new.png' : 'icons/32x/mail.png';
         $ph['action'] = 'index.php?a=10';
@@ -21,7 +21,7 @@ function iconElements()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('new_template') || evo()->hasPermission('edit_template') || evo()->hasPermission('new_snippet') || evo()->hasPermission('edit_snippet') || evo()->hasPermission('new_plugin') || evo()->hasPermission('edit_plugin')) {
         $ph['imgsrc'] = 'icons/32x/elements.png';
         $ph['action'] = 'index.php?a=76';
@@ -34,7 +34,7 @@ function iconNewDoc()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('new_document') || evo()->hasPermission('save_document')) {
         $ph['imgsrc'] = 'icons/32x/newdoc.png';
         $ph['action'] = 'index.php?a=4';
@@ -47,7 +47,7 @@ function iconSettings()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('settings')) {
         $ph['imgsrc'] = 'icons/32x/settings.png';
         $ph['action'] = 'index.php?a=17';
@@ -60,7 +60,7 @@ function iconResources()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('view_document')) {
         $ph['imgsrc'] = 'icons/32x/resources.png';
         $ph['action'] = 'index.php?a=120';
@@ -73,7 +73,7 @@ function iconHelp()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('help')) {
         $ph['imgsrc'] = 'icons/32x/help.png';
         $ph['action'] = 'index.php?a=9';
@@ -86,7 +86,7 @@ function iconFileManager()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('file_manager')) {
         $ph['imgsrc'] = 'icons/32x/files.png';
         $ph['action'] = 'index.php?a=31';
@@ -99,7 +99,7 @@ function iconEventLog()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('view_eventlog')) {
         $ph['imgsrc'] = 'icons/32x/log.png';
         $ph['action'] = 'index.php?a=114';
@@ -112,7 +112,7 @@ function iconSysInfo()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('logs')) {
         $ph['imgsrc'] = 'icons/32x/info.png';
         $ph['action'] = 'index.php?a=53';
@@ -125,7 +125,7 @@ function iconSearch()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     $ph['imgsrc'] = 'icons/32x/search.png';
     $ph['action'] = 'index.php?a=71';
     $ph['title'] = $_lang['search_resource'];
@@ -136,7 +136,7 @@ function tabYourInfo()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
 
     $ph = $_lang;
 
@@ -224,7 +224,7 @@ function tabOnlineUser()
 {
     global $modx, $_lang, $style_tree_path;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     $ph = $_lang;
     $timetocheck = (time() - (60 * 20));//+$server_offset_time;
 

--- a/manager/media/style/SoftSlate/welcome.php
+++ b/manager/media/style/SoftSlate/welcome.php
@@ -8,7 +8,7 @@ function iconMessage()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('messages')) {
         $ph['imgsrc'] = (sessionv('nrnewmessages', 0) > 0) ? 'icons/32x/mail_new.png' : 'icons/32x/mail.png';
         $ph['action'] = 'index.php?a=10';
@@ -21,7 +21,7 @@ function iconElements()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('new_template') || evo()->hasPermission('edit_template') || evo()->hasPermission('new_snippet') || evo()->hasPermission('edit_snippet') || evo()->hasPermission('new_plugin') || evo()->hasPermission('edit_plugin')) {
         $ph['imgsrc'] = 'icons/32x/elements.png';
         $ph['action'] = 'index.php?a=76';
@@ -34,7 +34,7 @@ function iconNewDoc()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('new_document') || evo()->hasPermission('save_document')) {
         $ph['imgsrc'] = 'icons/32x/newdoc.png';
         $ph['action'] = 'index.php?a=4';
@@ -47,7 +47,7 @@ function iconSettings()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('settings')) {
         $ph['imgsrc'] = 'icons/32x/settings.png';
         $ph['action'] = 'index.php?a=17';
@@ -60,7 +60,7 @@ function iconResources()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('view_document')) {
         $ph['imgsrc'] = 'icons/32x/resources.png';
         $ph['action'] = 'index.php?a=120';
@@ -73,7 +73,7 @@ function iconHelp()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('help')) {
         $ph['imgsrc'] = 'icons/32x/help.png';
         $ph['action'] = 'index.php?a=9';
@@ -86,7 +86,7 @@ function iconFileManager()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('file_manager')) {
         $ph['imgsrc'] = 'icons/32x/files.png';
         $ph['action'] = 'index.php?a=31';
@@ -99,7 +99,7 @@ function iconEventLog()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('view_eventlog')) {
         $ph['imgsrc'] = 'icons/32x/log.png';
         $ph['action'] = 'index.php?a=114';
@@ -112,7 +112,7 @@ function iconSysInfo()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     if (evo()->hasPermission('logs')) {
         $ph['imgsrc'] = 'icons/32x/info.png';
         $ph['action'] = 'index.php?a=53';
@@ -125,7 +125,7 @@ function iconSearch()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     $ph['imgsrc'] = 'icons/32x/search.png';
     $ph['action'] = 'index.php?a=71';
     $ph['title'] = $_lang['search_resource'];
@@ -136,7 +136,7 @@ function tabYourInfo()
 {
     global $modx, $_lang;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
 
     $ph = $_lang;
 
@@ -224,7 +224,7 @@ function tabOnlineUser()
 {
     global $modx, $_lang, $style_tree_path;
 
-    if (getv('a') != 2) return;
+    if (!manager_is_dashboard_action()) return;
     $ph = $_lang;
     $timetocheck = (time() - (60 * 20));//+$server_offset_time;
 


### PR DESCRIPTION
## 概要
- 管理画面ダッシュボードを `/manager/` でも開けるようにした
- `index.php?a=2` から `/manager/` への正規化を追加した
- メニューとダッシュボードのホーム導線も `/manager/` を優先するようにした

## 原因
- ダッシュボード表示が `a=2` 前提で、ルートURLは内部的に常にクエリ付きURLへ寄せていた

## 確認
- `php -l manager/index.php`
- `php -l manager/frames/menu.php`
- `php -l manager/actions/main/welcome.static.php`
- `git diff --check`
- `node -e "const fs=require('fs'); new Function(fs.readFileSync('manager/media/script/shell.js','utf8'));"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * マネージャーのホーム画面を、より一貫したURLで表示・遷移できるようになりました。
  * ホーム画面へのアクセス時に、不要なパラメータを省いた正規URLへ自動的に移動します。

* **改善**
  * ホーム画面専用のアイコンやタブが、対象画面でのみ表示されるよう表示判定を統一しました。
  * メニューや画面遷移で、ホームへのリンク先が適切に処理されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->