### PR TITLE
fix(tinymce7): 画像編集ダイアログを中央表示する

### DIFF
--- a/assets/plugins/tinymce7/js/tinymce-cropper.js
+++ b/assets/plugins/tinymce7/js/tinymce-cropper.js
@@ -160,6 +160,15 @@
     if (typeof cleanup === 'function') cleanup();
   }
 
+  function resolveOverlayHost() {
+    const mainPane = document.getElementById('mainPane');
+    if (mainPane instanceof HTMLElement) {
+      return mainPane;
+    }
+
+    return document.body;
+  }
+
   function showAlert(editor, message) {
     if (editor && editor.windowManager) {
       editor.windowManager.alert(message);
@@ -241,7 +250,7 @@
       dialog.appendChild(actions);
 
       overlay.appendChild(dialog);
-      document.body.appendChild(overlay);
+      resolveOverlayHost().appendChild(overlay);
       overlay.focus();
 
       let cropperInstance = null;


### PR DESCRIPTION
## 概要
- TinyMCE7 の画像編集ダイアログを manager shell 上でも中央表示されるよう修正
- cropper オーバーレイの挿入先を `document.body` 固定から `#mainPane` 優先へ変更

## 原因
manager shell のレイアウト保護 CSS により、`body` 直下に追加された補助要素がゼロサイズ化されていました。画像編集オーバーレイがこの対象に入り、ダイアログの一部だけが左上に表示されていました。

## 変更内容
- `resolveOverlayHost()` を追加し、`#mainPane` が存在する場合はそこへオーバーレイを追加
- `#mainPane` がない環境では従来どおり `document.body` へフォールバック

## 影響
- manager shell 上の TinyMCE7 画像編集ダイアログが中央にバランスよく表示されます
- shell の既存 CSS 保護ルールは変更しないため、他の補助要素への影響を避けられます

## 確認
- 画像をダブルクリックした際に、画像編集ダイアログが中央表示されることを手動確認
- 自動テストは未実施
