### PR TITLE
fix(shell): href#リンクの不要な履歴更新を抑止

### DIFF
--- a/manager/media/script/shell.js
+++ b/manager/media/script/shell.js
@@ -650,7 +650,7 @@
 
         window.history.replaceState({ url: window.location.href }, '', window.location.href);
 
-        // リンククリックの委譲。data-no-ajax / target付き / 外部URL / #アンカーは素通しする
+        // リンククリックの委譲。data-no-ajax / target付き / 外部URLは素通しする
         document.addEventListener('click', function (e) {
             if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) {
                 return;
@@ -664,6 +664,12 @@
                 return;
             }
             if (href.startsWith('#')) {
+                // href="#" はボタン用途のリンクでもブラウザの履歴を変更するため、
+                // クリックハンドラからシェル遷移した後の二重取得を防ぐ
+                if (href === '#') {
+                    e.preventDefault();
+                    return;
+                }
                 const url = new URL(window.location.href);
                 url.hash = href;
                 const pane = document.getElementById('mainPane');


### PR DESCRIPTION
## 概要
- `href="#"` のリンククリックで不要な履歴変更が起きないように修正
- シェル遷移後に同一URLの再取得が重なるケースを防止

## 原因
- `href="#"` を通常のハッシュ遷移として扱っており、ボタン用途のリンクでもブラウザ履歴が更新されていたため

## 影響
- 管理画面シェル内で `href="#"` を使う UI の不要な再読込リスクを下げる

## 確認
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * ボタン用途の「#」リンクで、不要な画面更新や履歴変更が発生しないよう改善しました。
  * 外部リンクや新しいタブで開くリンクなどが、意図せずアプリ内遷移として処理されない方針を明確化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->