### PR TITLE
fix(manager): パスワード入力欄のlabel関連付けを修正

### DIFF
--- a/manager/actions/permission/mutate_user/tpl/form/tab_general.php
+++ b/manager/actions/permission/mutate_user/tpl/form/tab_general.php
@@ -57,6 +57,7 @@
                 type="text"
                 class="inputBox"
                 maxlength="100"
+                autocomplete="username"
             /></td>
     </tr>
     <tr>
@@ -109,7 +110,7 @@
                             type="password"
                             onkeypress="document.userform.passwordgenmethod[1].checked=true;"
                             size="20"
-                            autocomplete="off"
+                            autocomplete="new-password"
                         /><br/>
                         <label for="confirmpassword" style="width:120px">
                             <?= lang('change_password_confirm') ?>:
@@ -120,7 +121,7 @@
                             type="password"
                             onkeypress="document.userform.passwordgenmethod[1].checked=true;"
                             size="20"
-                            autocomplete="off"
+                            autocomplete="new-password"
                         /><br/>
                         <span
                             class="warning"
@@ -159,6 +160,7 @@
                 value="<?= hsc(user('email')) ?>"
                 type="text"
                 class="inputBox"
+                autocomplete="email"
             />
             <input
                 name="oldemail"

--- a/manager/actions/permission/mutate_user/tpl/form/tab_general.php
+++ b/manager/actions/permission/mutate_user/tpl/form/tab_general.php
@@ -104,6 +104,7 @@
                             <?= lang('change_password_new') ?>:
                         </label>
                         <input
+                            id="specifiedpassword"
                             name="specifiedpassword"
                             type="password"
                             onkeypress="document.userform.passwordgenmethod[1].checked=true;"
@@ -114,6 +115,7 @@
                             <?= lang('change_password_confirm') ?>:
                         </label>
                         <input
+                            id="confirmpassword"
                             name="confirmpassword"
                             type="password"
                             onkeypress="document.userform.passwordgenmethod[1].checked=true;"

--- a/manager/actions/permission/mutate_user/tpl/form/tab_profile.php
+++ b/manager/actions/permission/mutate_user/tpl/form/tab_profile.php
@@ -7,6 +7,7 @@
                 value="<?= hsc(user('fullname', '')) ?>"
                 type="text"
                 class="inputBox"
+                autocomplete="name"
             /></td>
     </tr>
     <tr>
@@ -16,6 +17,7 @@
                 value="<?= hsc(user('phone')) ?>"
                 type="text"
                 class="inputBox"
+                autocomplete="tel"
             /></td>
     </tr>
     <tr>
@@ -25,6 +27,7 @@
                 value="<?= hsc(user('mobilephone')) ?>"
                 type="text"
                 class="inputBox"
+                autocomplete="tel"
             /></td>
     </tr>
     <tr>
@@ -34,6 +37,7 @@
                 value="<?= hsc(user('fax')) ?>"
                 type="text"
                 class="inputBox"
+                autocomplete="tel"
             /></td>
     </tr>
     <tr>
@@ -43,6 +47,7 @@
                 value="<?= hsc(user('street')) ?>"
                 type="text"
                 class="inputBox"
+                autocomplete="street-address"
                 onchange="documentDirty=true;"
             /></td>
     </tr>
@@ -53,6 +58,7 @@
                 value="<?= hsc(user('city')) ?>"
                 type="text"
                 class="inputBox"
+                autocomplete="address-level2"
                 onchange="documentDirty=true;"
             /></td>
     </tr>
@@ -64,6 +70,7 @@
                 value="<?= hsc(user('state')) ?>"
                 type="text"
                 class="inputBox"
+                autocomplete="address-level1"
             /></td>
     </tr>
     <tr>
@@ -73,12 +80,13 @@
                 value="<?= hsc(user('zip')) ?>"
                 type="text"
                 class="inputBox"
+                autocomplete="postal-code"
             /></td>
     </tr>
     <tr>
         <th><?= lang('user_country') ?>:</th>
         <td>
-            <select size="1" name="country" class="inputBox">
+            <select size="1" name="country" class="inputBox" autocomplete="country-name">
                 <?php $chosenCountry = postv('country', user('country')); ?>
                 <option
                     value="" <?= selected(empty($chosenCountry)) ?>

--- a/manager/actions/permission/mutate_user_pf.dynamic.php
+++ b/manager/actions/permission/mutate_user_pf.dynamic.php
@@ -230,10 +230,10 @@ if ($modx->config['manager_language'] != "english" && is_file($lang_path)) {
                                     <div style="padding-left:20px">
                                         <label for="specifiedpassword" style="width:120px"><?= $_lang['change_password_new'] ?>:</label>
                                         <input type="password" id="specifiedpassword" name="specifiedpassword" onkeypress="document.userform.passwordgenmethod[1].checked=true;"
-                                            size="20" autocomplete="off" /><br />
+                                            size="20" autocomplete="new-password" /><br />
                                         <label for="confirmpassword" style="width:120px"><?= $_lang['change_password_confirm'] ?>:</label>
                                         <input type="password" id="confirmpassword" name="confirmpassword" onkeypress="document.userform.passwordgenmethod[1].checked=true;"
-                                            size="20" autocomplete="off" /><br />
+                                            size="20" autocomplete="new-password" /><br />
                                         <small><span class="warning" style="font-weight:normal"><?= $_lang['password_gen_length'] ?></span></small>
                                     </div>
                                 </fieldset>
@@ -244,7 +244,7 @@ if ($modx->config['manager_language'] != "english" && is_file($lang_path)) {
                     <tr>
                         <th><?= $_lang['user_email'] ?>:</th>
                         <td>
-                            <input type="text" name="email" class="inputBox"
+                            <input type="text" name="email" class="inputBox" autocomplete="email"
                                 value="<?= hsc(userData('email')) ?>" />
                             <input type="hidden" name="oldemail"
                                 value="<?= hsc(userData('oldemail') ?: userData('email')) ?>" />
@@ -252,50 +252,50 @@ if ($modx->config['manager_language'] != "english" && is_file($lang_path)) {
                     </tr>
                     <tr>
                         <th><?= $_lang['user_full_name'] ?>:</th>
-                        <td><input type="text" name="fullname" class="inputBox"
+                        <td><input type="text" name="fullname" class="inputBox" autocomplete="name"
                                 value="<?= hsc(userData('fullname')) ?>" /></td>
                     </tr>
                     <tr>
                         <th><?= $_lang['user_phone'] ?>:</th>
-                        <td><input type="text" name="phone" class="inputBox"
+                        <td><input type="text" name="phone" class="inputBox" autocomplete="tel"
                                 value="<?= hsc(userData('phone')) ?>" /></td>
                     </tr>
                     <tr>
                         <th><?= $_lang['user_mobile'] ?>:</th>
-                        <td><input type="text" name="mobilephone" class="inputBox"
+                        <td><input type="text" name="mobilephone" class="inputBox" autocomplete="tel"
                                 value="<?= hsc(userData('mobilephone')) ?>" /></td>
                     </tr>
                     <tr>
                         <th><?= $_lang['user_fax'] ?>:</th>
-                        <td><input type="text" name="fax" class="inputBox"
+                        <td><input type="text" name="fax" class="inputBox" autocomplete="tel"
                                 value="<?= hsc(userData('fax')) ?>" /></td>
                     </tr>
                     <tr>
                         <th><?= $_lang['user_street'] ?>:</th>
-                        <td><input type="text" name="street" class="inputBox"
+                        <td><input type="text" name="street" class="inputBox" autocomplete="street-address"
                                 value="<?= hsc(userData('street')) ?>"
                                 onchange="documentDirty=true;" /></td>
                     </tr>
                     <tr>
                         <th><?= $_lang['user_city'] ?>:</th>
-                        <td><input type="text" name="city" class="inputBox"
+                        <td><input type="text" name="city" class="inputBox" autocomplete="address-level2"
                                 value="<?= hsc(userData('city')) ?>"
                                 onchange="documentDirty=true;" /></td>
                     </tr>
                     <tr>
                         <th><?= $_lang['user_state'] ?>:</th>
-                        <td><input type="text" name="state" class="inputBox"
+                        <td><input type="text" name="state" class="inputBox" autocomplete="address-level1"
                                 value="<?= hsc(userData('state')) ?>" /></td>
                     </tr>
                     <tr>
                         <th><?= $_lang['user_zip'] ?>:</th>
-                        <td><input type="text" name="zip" class="inputBox"
+                        <td><input type="text" name="zip" class="inputBox" autocomplete="postal-code"
                                 value="<?= hsc(userData('zip')) ?>" /></td>
                     </tr>
                     <tr>
                         <th><?= $_lang['user_country'] ?>:</th>
                         <td>
-                            <select size="1" name="country" class="inputBox">
+                            <select size="1" name="country" class="inputBox" autocomplete="country-name">
                                 <?php $chosenCountry = isset($_POST['country']) ? $_POST['country'] : $userdata['country']; ?>
                                 <option value="" <?= selected(empty($chosenCountry)) ?>>&nbsp;</option>
                                 <?php

--- a/manager/actions/permission/mutate_user_pf.dynamic.php
+++ b/manager/actions/permission/mutate_user_pf.dynamic.php
@@ -229,10 +229,10 @@ if ($modx->config['manager_language'] != "english" && is_file($lang_path)) {
                                             value="spec" <?= postv('passwordgenmethod') == "spec" ? 'checked="checked"' : "" ?>><?= $_lang['password_gen_specify'] ?></label><br />
                                     <div style="padding-left:20px">
                                         <label for="specifiedpassword" style="width:120px"><?= $_lang['change_password_new'] ?>:</label>
-                                        <input type="password" name="specifiedpassword" onkeypress="document.userform.passwordgenmethod[1].checked=true;"
+                                        <input type="password" id="specifiedpassword" name="specifiedpassword" onkeypress="document.userform.passwordgenmethod[1].checked=true;"
                                             size="20" autocomplete="off" /><br />
                                         <label for="confirmpassword" style="width:120px"><?= $_lang['change_password_confirm'] ?>:</label>
-                                        <input type="password" name="confirmpassword" onkeypress="document.userform.passwordgenmethod[1].checked=true;"
+                                        <input type="password" id="confirmpassword" name="confirmpassword" onkeypress="document.userform.passwordgenmethod[1].checked=true;"
                                             size="20" autocomplete="off" /><br />
                                         <small><span class="warning" style="font-weight:normal"><?= $_lang['password_gen_length'] ?></span></small>
                                     </div>

--- a/manager/actions/permission/mutate_web_user.dynamic.php
+++ b/manager/actions/permission/mutate_web_user.dynamic.php
@@ -305,7 +305,7 @@ if ($manager_language != "english" && is_file(MODX_CORE_PATH . "lang/country/{$m
                     <tr id="editname"
                         style="display:<?= getv('a') == '87' || (webuser('oldusername') && webuser('oldusername') != webuser('username')) ? 'table-row' : 'none' ?>">
                         <th><?= $_lang['username'] ?>:</th>
-                        <td><input type="text" name="newusername" class="inputBox"
+                        <td><input type="text" name="newusername" class="inputBox" autocomplete="username"
                                 value="<?= hsc(postv('newusername', webuser('username'))) ?>"
                                 maxlength="100" /></td>
                     </tr>
@@ -333,13 +333,13 @@ if ($manager_language != "english" && is_file(MODX_CORE_PATH . "lang/country/{$m
                                             :</label>
                                         <input type="password" id="specifiedpassword" name="specifiedpassword"
                                             onkeypress="document.userform.passwordgenmethod[1].checked=true;"
-                                            size="20" autocomplete="off" /><br />
+                                            size="20" autocomplete="new-password" /><br />
                                         <label for="confirmpassword"
                                             style="width:120px"><?= $_lang['change_password_confirm'] ?>
                                             :</label>
                                         <input type="password" id="confirmpassword" name="confirmpassword"
                                             onkeypress="document.userform.passwordgenmethod[1].checked=true;"
-                                            size="20" autocomplete="off" /><br />
+                                            size="20" autocomplete="new-password" /><br />
                                         <span class="warning"
                                             style="font-weight:normal"><?= $_lang['password_gen_length'] ?></span>
                                     </div>
@@ -359,7 +359,7 @@ if ($manager_language != "english" && is_file(MODX_CORE_PATH . "lang/country/{$m
                     <tr>
                         <th><?= $_lang['user_email'] ?>:</th>
                         <td>
-                            <input type="text" name="email" class="inputBox"
+                            <input type="text" name="email" class="inputBox" autocomplete="email"
                                 value="<?= postv('email', attribute('email')) ?>" />
                             <input type="hidden" name="oldemail"
                                 value="<?= hsc(attribute('oldemail') ?: attribute('email')) ?>" />
@@ -373,56 +373,56 @@ if ($manager_language != "english" && is_file(MODX_CORE_PATH . "lang/country/{$m
                 <table class="settings">
                     <tr>
                         <th><?= $_lang['user_full_name'] ?>:</th>
-                        <td><input type="text" name="fullname" class="inputBox"
+                        <td><input type="text" name="fullname" class="inputBox" autocomplete="name"
                                 value="<?= hsc(postv('fullname', attribute('fullname'))) ?>" />
                         </td>
                     </tr>
                     <tr>
                         <th><?= $_lang['user_phone'] ?>:</th>
-                        <td><input type="text" name="phone" class="inputBox"
+                        <td><input type="text" name="phone" class="inputBox" autocomplete="tel"
                                 value="<?= postv('phone', attribute('phone')) ?>" />
                         </td>
                     </tr>
                     <tr>
                         <th><?= $_lang['user_mobile'] ?>:</th>
-                        <td><input type="text" name="mobilephone" class="inputBox"
+                        <td><input type="text" name="mobilephone" class="inputBox" autocomplete="tel"
                                 value="<?= postv('mobilephone', attribute('mobilephone')) ?>" />
                         </td>
                     </tr>
                     <tr>
                         <th><?= $_lang['user_fax'] ?>:</th>
-                        <td><input type="text" name="fax" class="inputBox"
+                        <td><input type="text" name="fax" class="inputBox" autocomplete="tel"
                                 value="<?= postv('fax', attribute('fax')) ?>" />
                         </td>
                     </tr>
                     <tr>
                         <th><?= $_lang['user_street'] ?>:</th>
-                        <td><input type="text" name="street" class="inputBox"
+                        <td><input type="text" name="street" class="inputBox" autocomplete="street-address"
                                 value="<?= hsc(attribute('street')) ?>"
                                 onchange="documentDirty=true;" /></td>
                     </tr>
                     <tr>
                         <th><?= $_lang['user_city'] ?>:</th>
-                        <td><input type="text" name="city" class="inputBox"
+                        <td><input type="text" name="city" class="inputBox" autocomplete="address-level2"
                                 value="<?= hsc(attribute('city')) ?>"
                                 onchange="documentDirty=true;" /></td>
                     </tr>
                     <tr>
                         <th><?= $_lang['user_state'] ?>:</th>
-                        <td><input type="text" name="state" class="inputBox"
+                        <td><input type="text" name="state" class="inputBox" autocomplete="address-level1"
                                 value="<?= postv('state', attribute('state')) ?>" />
                         </td>
                     </tr>
                     <tr>
                         <th><?= $_lang['user_zip'] ?>:</th>
-                        <td><input type="text" name="zip" class="inputBox"
+                        <td><input type="text" name="zip" class="inputBox" autocomplete="postal-code"
                                 value="<?= postv('zip', attribute('zip')) ?>" />
                         </td>
                     </tr>
                     <tr>
                         <th><?= $_lang['user_country'] ?>:</th>
                         <td>
-                            <select size="1" name="country">
+                            <select size="1" name="country" autocomplete="country-name">
                                 <?php $chosenCountry = postv('country', attribute('country')); ?>
                                 <option value="" <?php (!$chosenCountry ? ' selected' : '') ?>>&nbsp;
                                 </option>

--- a/manager/actions/permission/mutate_web_user.dynamic.php
+++ b/manager/actions/permission/mutate_web_user.dynamic.php
@@ -331,13 +331,13 @@ if ($manager_language != "english" && is_file(MODX_CORE_PATH . "lang/country/{$m
                                         <label for="specifiedpassword"
                                             style="width:120px"><?= $_lang['change_password_new'] ?>
                                             :</label>
-                                        <input type="password" name="specifiedpassword"
+                                        <input type="password" id="specifiedpassword" name="specifiedpassword"
                                             onkeypress="document.userform.passwordgenmethod[1].checked=true;"
                                             size="20" autocomplete="off" /><br />
                                         <label for="confirmpassword"
                                             style="width:120px"><?= $_lang['change_password_confirm'] ?>
                                             :</label>
-                                        <input type="password" name="confirmpassword"
+                                        <input type="password" id="confirmpassword" name="confirmpassword"
                                             onkeypress="document.userform.passwordgenmethod[1].checked=true;"
                                             size="20" autocomplete="off" /><br />
                                         <span class="warning"


### PR DESCRIPTION
## 概要
- パスワード変更フォームの label for と対応 input の関連付けを修正
- specifiedpassword と confirmpassword に id を追加
- 管理ユーザー編集と Web ユーザー編集の両系統へ横展開

## 確認
- php -l manager/actions/permission/mutate_user/tpl/form/tab_general.php
- php -l manager/actions/permission/mutate_user_pf.dynamic.php
- php -l manager/actions/permission/mutate_web_user.dynamic.php